### PR TITLE
🗃️ fix: is_join migration + tracked migration runner

### DIFF
--- a/database/schema/migrations/20260529_add_is_join_to_join_leave.sql
+++ b/database/schema/migrations/20260529_add_is_join_to_join_leave.sql
@@ -1,0 +1,39 @@
+-- =============================================================
+-- Migration: add is_join boolean to join_leave (production hotfix)
+-- Date: 2026-05-29
+-- =============================================================
+-- Production was missing the is_join column that the deployed code
+-- (cogs/stats.py, cogs/stats_listeners.py) requires. This extracts
+-- the safe, additive steps from 20260405_database_design_cleanup.sql
+-- (SECTION 5) so production can be reconciled without running the
+-- heavier, table-locking sections of that migration.
+--
+-- Idempotent and safe to run online. Does NOT drop join_or_leave;
+-- both columns coexist (matching staging) until the full cleanup
+-- migration is applied in a maintenance window.
+-- =============================================================
+
+-- Step 1: Add the boolean column alongside the old varchar one.
+ALTER TABLE join_leave
+    ADD COLUMN IF NOT EXISTS is_join boolean;
+
+-- Step 2: Backfill from the existing varchar column.
+-- COALESCE handles any unexpected NULL join_or_leave rows (-> FALSE/leave).
+UPDATE join_leave
+    SET is_join = COALESCE(join_or_leave = 'join', FALSE)
+    WHERE is_join IS NULL;
+
+-- Step 3: Enforce NOT NULL once the backfill is complete.
+-- DO block keeps this idempotent on re-run.
+DO $$
+BEGIN
+    IF EXISTS (
+        SELECT 1 FROM information_schema.columns
+        WHERE table_schema = 'public'
+          AND table_name   = 'join_leave'
+          AND column_name  = 'is_join'
+          AND is_nullable  = 'YES'
+    ) THEN
+        ALTER TABLE join_leave ALTER COLUMN is_join SET NOT NULL;
+    END IF;
+END $$;

--- a/railway.toml
+++ b/railway.toml
@@ -1,0 +1,11 @@
+# Railway configuration (config-as-code).
+# Only fields set here override the dashboard; everything else (builder,
+# start command, etc.) continues to use the service's dashboard settings.
+
+[deploy]
+# Run pending SQL schema migrations before the new code goes live, so code and
+# database schema stay in sync. Heavy/locking migrations are excluded via
+# MANUAL_MIGRATIONS in the script and applied by hand in a maintenance window.
+# A non-zero exit here aborts the deploy (intended: don't ship code against an
+# un-migrated schema).
+preDeployCommand = "python scripts/database/apply_migrations.py"

--- a/scripts/database/apply_migrations.py
+++ b/scripts/database/apply_migrations.py
@@ -1,0 +1,145 @@
+#!/usr/bin/env python3
+"""Apply pending SQL schema migrations, tracked in a schema_migrations table.
+
+Designed to run as a Railway pre-deploy step so code and database schema stay
+in sync. Migrations live in ``database/schema/migrations/*.sql`` and are applied
+in filename order (use a sortable ``YYYYMMDD_description.sql`` prefix).
+
+Behaviour
+---------
+* Ensures a ``schema_migrations`` tracking table exists.
+* Migrations listed in ``MANUAL_MIGRATIONS`` are **recorded as applied without
+  being executed**. Use this for heavy / table-locking migrations that must be
+  run by hand in a maintenance window (e.g. type changes, sequence rewrites,
+  materialized-view rebuilds). The runner must never lock production tables
+  unexpectedly during a deploy.
+* Every other migration not yet recorded is executed inside a transaction and
+  then recorded.
+
+Requirements for migrations
+---------------------------
+* Idempotent (``IF NOT EXISTS`` / guarded ``DO`` blocks) so an interrupted or
+  retried deploy is safe, and so a migration that was already applied by hand
+  is harmless to re-run.
+* Single-transaction safe — statements that cannot run inside a transaction
+  (e.g. ``CREATE INDEX CONCURRENTLY``) must be added to ``MANUAL_MIGRATIONS``
+  and run by hand.
+
+Usage
+-----
+    python scripts/database/apply_migrations.py            # apply pending
+    python scripts/database/apply_migrations.py --dry-run  # show plan only
+
+Requires ``DATABASE_URL`` in the environment.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import os
+import sys
+from pathlib import Path
+
+import asyncpg
+
+MIGRATIONS_DIR = (
+    Path(__file__).resolve().parents[2] / "database" / "schema" / "migrations"
+)
+
+# Migrations applied by hand in a maintenance window, never by the auto-runner.
+# The runner records them as applied (so they don't show as pending) but does
+# not execute them. Add heavy / table-locking / non-transactional migrations
+# here.
+MANUAL_MIGRATIONS: frozenset[str] = frozenset(
+    {
+        "20260405_database_design_cleanup.sql",
+    }
+)
+
+CREATE_TRACKING_TABLE = """
+CREATE TABLE IF NOT EXISTS schema_migrations (
+    filename   text PRIMARY KEY,
+    applied_at timestamptz NOT NULL DEFAULT now()
+)
+"""
+
+
+def _normalize_dsn(dsn: str) -> str:
+    """Normalize a SQLAlchemy-style URL to a plain asyncpg DSN."""
+    return dsn.replace("postgresql+asyncpg://", "postgresql://").replace(
+        "postgres+asyncpg://", "postgresql://"
+    )
+
+
+def _discover_migrations() -> list[Path]:
+    """Return migration files sorted by filename (chronological prefix order)."""
+    if not MIGRATIONS_DIR.is_dir():
+        return []
+    return sorted(p for p in MIGRATIONS_DIR.glob("*.sql") if p.is_file())
+
+
+async def apply_migrations(dry_run: bool = False) -> int:
+    """Apply pending migrations. Returns the number executed (-1 on config error)."""
+    dsn = os.getenv("DATABASE_URL")
+    if not dsn:
+        print("ERROR: DATABASE_URL is not set", file=sys.stderr)
+        return -1
+
+    migrations = _discover_migrations()
+    if not migrations:
+        print(f"No migration files found in {MIGRATIONS_DIR}")
+        return 0
+
+    conn = await asyncpg.connect(_normalize_dsn(dsn))
+    try:
+        await conn.execute(CREATE_TRACKING_TABLE)
+        recorded = {
+            row["filename"]
+            for row in await conn.fetch("SELECT filename FROM schema_migrations")
+        }
+
+        applied = 0
+        for migration in migrations:
+            name = migration.name
+            if name in recorded:
+                continue
+
+            if name in MANUAL_MIGRATIONS:
+                print(f"Recording manual migration (not executed): {name}")
+                if not dry_run:
+                    await conn.execute(
+                        "INSERT INTO schema_migrations(filename) VALUES ($1) "
+                        "ON CONFLICT DO NOTHING",
+                        name,
+                    )
+                continue
+
+            print(f"Applying migration: {name}")
+            if dry_run:
+                continue
+            async with conn.transaction():
+                await conn.execute(migration.read_text())
+                await conn.execute(
+                    "INSERT INTO schema_migrations(filename) VALUES ($1)", name
+                )
+            applied += 1
+            print(f"  ✓ applied {name}")
+
+        if applied == 0:
+            print("Schema is up to date; no migrations executed.")
+        else:
+            print(f"Done. Executed {applied} migration(s).")
+        return applied
+    finally:
+        await conn.close()
+
+
+def main() -> int:
+    """CLI entry point."""
+    dry_run = "--dry-run" in sys.argv
+    result = asyncio.run(apply_migrations(dry_run=dry_run))
+    return 1 if result < 0 else 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
Follow-up to #31. Fixes the production stats-loop error `column "is_join" does not exist` and closes the root-cause gap that caused it.

## Background

The `20260405_database_design_cleanup.sql` migration (renames `join_leave.join_or_leave` → `is_join`) was applied to staging but **never to production**. #31 shipped code that already references `is_join`, so the production daily stats loop began failing. The error DM surfaced because the `owner_id` fix from #31 is working.

## Changes

- **`database/schema/migrations/20260529_add_is_join_to_join_leave.sql`** — standalone, idempotent extract of that rename's *safe additive* steps (add column + backfill + `NOT NULL`). Reconciles production without the heavier table-locking sections of `20260405`.
- **`scripts/database/apply_migrations.py`** — tracked migration runner (`schema_migrations` table). Applies pending `*.sql` in filename order inside transactions. Heavy/locking migrations are listed in `MANUAL_MIGRATIONS` (currently `20260405`) and recorded-but-not-executed, so deploys never lock production tables unexpectedly.
- **`railway.toml`** — wires the runner as a `preDeployCommand` so code and schema stay in sync going forward. **A failed migration aborts the deploy by design** (don't ship code against an un-migrated schema).

## Deploy behaviour on merge

On the production deploy, the pre-deploy runner will:
1. Create `schema_migrations` if absent.
2. Record `20260405` as applied **without executing** (manual / maintenance-window only).
3. Apply `20260529` (idempotent — safe even if already run by hand).

## Verification

- Runner validated statically: correct discovery, `20260405` skipped, `20260529` auto-applied, clean handling of missing `DATABASE_URL`, ruff-clean, valid TOML.
- The same `preDeployCommand` runs on the staging deploy from this branch first, exercising the runner against a live DB before it reaches production.

## Notes / follow-ups (not in this PR)

- The immediate production fix can be applied by hand now via `railway connect` + the `20260529` SQL; the runner will harmlessly re-confirm it on deploy.
- The full `20260405` migration (type/sequence changes, view rebuilds) remains a manual maintenance-window task and stays in `MANUAL_MIGRATIONS`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)