### PR TITLE
👷 ci: make CI + security scans run on the right branches

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,36 +2,33 @@ name: CI
 
 on:
   push:
-    branches: [ main ]
+    branches: [ staging, production ]
   pull_request:
-    branches: [ main ]
+    branches: [ staging, production ]
 
 jobs:
   test:
     runs-on: ubuntu-latest
-    
+    env:
+      ENVIRONMENT: testing  # required: enables test config / lazy cog loading
+
     steps:
     - uses: actions/checkout@v4
-    
+
     - name: Set up Python
-      uses: actions/setup-python@v4
+      uses: actions/setup-python@v5
       with:
         python-version: '3.12'
-    
+
     - name: Install uv
-      run: |
-        curl -LsSf https://astral.sh/uv/install.sh | sh
-        echo "$HOME/.cargo/bin" >> $GITHUB_PATH
-    
+      uses: astral-sh/setup-uv@v5
+
     - name: Install dependencies
-      run: |
-        uv pip install -e .
-        uv pip install pytest pytest-asyncio pytest-cov hypothesis
-    
+      run: uv pip install --system -e ".[dev]"
+
     - name: Run tests
-      run: |
-        pytest tests/ --cov=. --cov-report=xml
-    
+      run: python -m pytest tests/ --cov=. --cov-report=xml
+
     - name: Upload coverage to Codecov
       uses: codecov/codecov-action@v4
       with:
@@ -40,61 +37,55 @@ jobs:
 
   lint:
     runs-on: ubuntu-latest
+    # Informational only for now: the repo has a large pre-existing ruff/mypy
+    # backlog (~1800 ruff, ~450 mypy). Kept non-blocking so it reports without
+    # failing CI. Remove `continue-on-error` once `ruff check .` and `mypy .`
+    # are clean to make lint a hard gate.
+    continue-on-error: true
 
     steps:
     - uses: actions/checkout@v4
 
     - name: Set up Python
-      uses: actions/setup-python@v4
+      uses: actions/setup-python@v5
       with:
         python-version: '3.12'
 
     - name: Install uv
-      run: |
-        curl -LsSf https://astral.sh/uv/install.sh | sh
-        echo "$HOME/.cargo/bin" >> $GITHUB_PATH
+      uses: astral-sh/setup-uv@v5
 
     - name: Install dependencies
-      run: |
-        uv pip install -e ".[dev]"
+      run: uv pip install --system -e ".[dev]"
 
     - name: Run ruff check
-      run: |
-        ruff check .
+      run: ruff check .
 
     - name: Run ruff format check
-      run: |
-        ruff format --check .
+      run: ruff format --check .
 
     - name: Run mypy
-      run: |
-        mypy .
+      run: mypy .
 
   build:
     runs-on: ubuntu-latest
-    
+    # Non-blocking: the bot deploys via Railway, not as a published package, so
+    # the build is a sanity check rather than a release gate.
+    continue-on-error: true
+
     steps:
     - uses: actions/checkout@v4
-    
+
     - name: Set up Python
-      uses: actions/setup-python@v4
+      uses: actions/setup-python@v5
       with:
         python-version: '3.12'
-    
+
     - name: Install uv
-      run: |
-        curl -LsSf https://astral.sh/uv/install.sh | sh
-        echo "$HOME/.cargo/bin" >> $GITHUB_PATH
-    
-    - name: Install dependencies
-      run: |
-        uv pip install -e .
-        uv pip install build
-    
+      uses: astral-sh/setup-uv@v5
+
     - name: Build package
-      run: |
-        python -m build
-    
+      run: uv build
+
     - name: Archive production artifacts
       uses: actions/upload-artifact@v4
       with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,6 +26,12 @@ jobs:
     - name: Install dependencies
       run: uv pip install --system -e ".[dev]"
 
+    - name: Provide test environment config
+      # config/__init__.py validates required env vars at import time. Locally
+      # these come from a developer's .env; in CI use the committed dummy
+      # values in .env.test (tests use SQLite/mocks, not a real database).
+      run: cp .env.test .env
+
     - name: Run tests
       run: python -m pytest tests/ --cov=. --cov-report=xml
 

--- a/.github/workflows/security-scan.yml
+++ b/.github/workflows/security-scan.yml
@@ -2,9 +2,9 @@ name: Security Scanning
 
 on:
   push:
-    branches: [ main ]
+    branches: [ staging, production ]
   pull_request:
-    branches: [ main ]
+    branches: [ staging, production ]
   schedule:
     - cron: '0 0 * * 0'  # Run weekly on Sunday at midnight
 
@@ -12,11 +12,15 @@ jobs:
   dependency-scan:
     name: Dependency Vulnerability Scan
     runs-on: ubuntu-latest
+    # Advisory: pip-audit exits non-zero on any known advisory (including
+    # transitive ones we can't immediately patch). Report via artifact without
+    # failing the workflow; flip off once findings are triaged to zero.
+    continue-on-error: true
     steps:
       - uses: actions/checkout@v4
 
       - name: Set up Python
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
           python-version: '3.12'
 
@@ -34,39 +38,46 @@ jobs:
         with:
           name: pip-audit-report
           path: pip-audit-report.json
-          
+
   static-analysis:
     name: Static Security Analysis
     runs-on: ubuntu-latest
+    # Advisory: bandit exits non-zero on any finding. Report via artifact
+    # without failing the workflow.
+    continue-on-error: true
     steps:
       - uses: actions/checkout@v4
-      
+
       - name: Set up Python
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
           python-version: '3.12'
-          
+
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
           pip install bandit
-          
+
       - name: Run Bandit
-        run: bandit -r . -x ./tests,./venv -f json -o bandit-report.json
-        
+        # Exclude tests and the virtualenv (.venv, not ./venv — the old path
+        # never matched, so bandit scanned third-party code in .venv).
+        run: bandit -r . -x ./tests,./.venv -f json -o bandit-report.json
+
       - name: Upload Bandit report
         if: always()
         uses: actions/upload-artifact@v4
         with:
           name: bandit-report
           path: bandit-report.json
-          
+
   secret-scanning:
     name: Secret Scanning
     runs-on: ubuntu-latest
+    # Hard gate: secret detection should block. Currently passing (no secrets
+    # in history).
     steps:
       - uses: actions/checkout@v4
-      
+
       - name: Run Gitleaks
         uses: gitleaks/gitleaks-action@v2
         env:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,6 +31,7 @@ dev = [
     "pytest-mock>=3.12.0",
     "pytest-timeout>=2.2.0",
     "pytest-asyncio>=1.0.0",
+    "pytest-cov>=5.0.0",
     "faker>=24.4.0",
     "hypothesis>=6.135.26",
     "aiosqlite>=0.20.0",

--- a/uv.lock
+++ b/uv.lock
@@ -264,6 +264,30 @@ wheels = [
 ]
 
 [[package]]
+name = "coverage"
+version = "7.14.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/54/fd/0ab2772530e946e1be1abd0bc09e647ec9b02e88f0867857601fefca8953/coverage-7.14.1.tar.gz", hash = "sha256:30c08f7d90415aa98b3c990385dea2939b0da55f38515e5b369b83655f8523be", size = 920132, upload-time = "2026-05-26T20:41:36.783Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/3d/b7/bdbb725ba02c5b42825b200c940f38b7a54fcad24627b7192f78f8110d76/coverage-7.14.1-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:a06c76364a9360e33d6d23769aefdf7f66f38e2ffb60ceb1baaa4989d83b695c", size = 220022, upload-time = "2026-05-26T20:39:03.702Z" },
+    { url = "https://files.pythonhosted.org/packages/72/81/fdc0898a55c6219223291ec1a1fe89966ef212ce82276aa0899df84b5de0/coverage-7.14.1-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:fad54e871165f6ec2f536063ac74c3104508a12963e64072ba44bd822de52b0c", size = 220379, upload-time = "2026-05-26T20:39:05.381Z" },
+    { url = "https://files.pythonhosted.org/packages/de/72/de048c4a25e13bce59ac6a339351c10bdf2515e07459afcdaf04dc3143a2/coverage-7.14.1-cp312-cp312-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:84b535f00655ecafe1d929d1fb00ed5d6fa3051ea643ab2c161a3887b86f294b", size = 251888, upload-time = "2026-05-26T20:39:07.367Z" },
+    { url = "https://files.pythonhosted.org/packages/28/30/300c343f68beb9d4cbb64ec81e58c5b6b80b56927f72d2b38654ac26e013/coverage-7.14.1-cp312-cp312-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:6b6b0853b895fe0e98cbfc580d1ec3393d9302b4b1e96a77b3f5c91fdab899e6", size = 254624, upload-time = "2026-05-26T20:39:09.037Z" },
+    { url = "https://files.pythonhosted.org/packages/b1/ed/7b25642496e8170b6bac14adce00537c6e5fa2d586159401a4de3e8b49e6/coverage-7.14.1-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:442cc9c952b2df400cda54bb04ab87330cf2cd08a8692cbbea36773531eb6f37", size = 255739, upload-time = "2026-05-26T20:39:10.889Z" },
+    { url = "https://files.pythonhosted.org/packages/7f/a2/abd210b8c4e29c24e4624916db97bb519097a91034aaeb767f937e7da794/coverage-7.14.1-cp312-cp312-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:8270544c361ed405a27a060dbc9ed2c124b084d96dfdc2d9a2510482aef981ad", size = 257998, upload-time = "2026-05-26T20:39:12.722Z" },
+    { url = "https://files.pythonhosted.org/packages/7f/24/7c50beed3792fe62f6ce0545c6686ce83379719e2c0276179333d97eae92/coverage-7.14.1-cp312-cp312-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:48b283b1dd6372e8de2a7a9a4c4d5dc06f4d4fd209b876f3c88a7a205a0c8f84", size = 252296, upload-time = "2026-05-26T20:39:14.259Z" },
+    { url = "https://files.pythonhosted.org/packages/15/05/0f874628ebcbfc77ead559ff210281ef06a97db08481832e7dd39274a135/coverage-7.14.1-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:5b0c99ba93a07d56f6df340bb79be53202a082b2fdb81bfe6190b741a3470d54", size = 253658, upload-time = "2026-05-26T20:39:15.923Z" },
+    { url = "https://files.pythonhosted.org/packages/99/6f/ca6ad067364b337ef997802115e7ecad2abd2248b05471464b0dea02b4d4/coverage-7.14.1-cp312-cp312-musllinux_1_2_i686.whl", hash = "sha256:e471bc5769ff073b058cfadb0d736b56ce067c8560eabeb0da88462df98c23e7", size = 251803, upload-time = "2026-05-26T20:39:17.537Z" },
+    { url = "https://files.pythonhosted.org/packages/c0/30/b9b4d377cd9f40baf228068f5a81faf8450c6228503011bd499708483a50/coverage-7.14.1-cp312-cp312-musllinux_1_2_ppc64le.whl", hash = "sha256:f497a1ea81d4cd7c10ddcaa685135b9aabd291af3d55775a9ddf3cb7a364cdd9", size = 255873, upload-time = "2026-05-26T20:39:19.414Z" },
+    { url = "https://files.pythonhosted.org/packages/3c/21/7c721a9e5e6bb88547d30a787aefb97512d3f54c1324c7488d9b3743f7f9/coverage-7.14.1-cp312-cp312-musllinux_1_2_riscv64.whl", hash = "sha256:2222be86d0b54f5dd5a38f45f17f315f737245e857bf0bdedc70734f84a13c02", size = 251372, upload-time = "2026-05-26T20:39:21.169Z" },
+    { url = "https://files.pythonhosted.org/packages/9d/8c/f8ae5a2200130e1503cd7661a6cd3b2b7bacef98277fbf3571fb13f8b766/coverage-7.14.1-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:85e85586565842f6932abebd4c18bcb1074223dc0b3576e7d173ca710622813a", size = 253245, upload-time = "2026-05-26T20:39:23.097Z" },
+    { url = "https://files.pythonhosted.org/packages/34/62/70a9024672a5f6910517d9628c52c9afbdd3cf8f46426af52bb148a56fff/coverage-7.14.1-cp312-cp312-win32.whl", hash = "sha256:4a28fd227808366b196a75476dced2eb35b351d6766ba9c858dc93319e87f4f1", size = 222567, upload-time = "2026-05-26T20:39:24.868Z" },
+    { url = "https://files.pythonhosted.org/packages/f6/81/8b7cd386839b039ebe1855733b9f9449a8dec5d79564018234f185a7fa70/coverage-7.14.1-cp312-cp312-win_amd64.whl", hash = "sha256:54acdb6674a4661768d7bf7db32dfb9f46ab1d764f8aba6df75ce1a6a088724e", size = 223372, upload-time = "2026-05-26T20:39:26.603Z" },
+    { url = "https://files.pythonhosted.org/packages/ae/ba/b44d472022f620d289d95fa830143235c0c36461c6f2437ea8d51e5481ed/coverage-7.14.1-cp312-cp312-win_arm64.whl", hash = "sha256:99cd41ff91afd94896fea3bc002706b6ae4ce95727d06e4a0f39c0a8d8bd8b1a", size = 221989, upload-time = "2026-05-26T20:39:28.242Z" },
+    { url = "https://files.pythonhosted.org/packages/8a/3c/1a983b9a745d7f83d53f057bcc5bf79ba6a2bbc08266b3f0c7d6fe630c9b/coverage-7.14.1-py3-none-any.whl", hash = "sha256:a252f21c27e38347e60111a3266b03827422a7d5525951aceee313aa68bab1d2", size = 211815, upload-time = "2026-05-26T20:41:34.078Z" },
+]
+
+[[package]]
 name = "cryptography"
 version = "48.0.0"
 source = { registry = "https://pypi.org/simple" }
@@ -1065,6 +1089,20 @@ wheels = [
 ]
 
 [[package]]
+name = "pytest-cov"
+version = "7.1.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "coverage" },
+    { name = "pluggy" },
+    { name = "pytest" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/b1/51/a849f96e117386044471c8ec2bd6cfebacda285da9525c9106aeb28da671/pytest_cov-7.1.0.tar.gz", hash = "sha256:30674f2b5f6351aa09702a9c8c364f6a01c27aae0c1366ae8016160d1efc56b2", size = 55592, upload-time = "2026-03-21T20:11:16.284Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/9d/7a/d968e294073affff457b041c2be9868a40c1c71f4a35fcc1e45e5493067b/pytest_cov-7.1.0-py3-none-any.whl", hash = "sha256:a0461110b7865f9a271aa1b51e516c9a95de9d696734a2f71e3e78f46e1d4678", size = 22876, upload-time = "2026-03-21T20:11:14.438Z" },
+]
+
+[[package]]
 name = "pytest-mock"
 version = "3.15.1"
 source = { registry = "https://pypi.org/simple" }
@@ -1267,6 +1305,7 @@ dev = [
     { name = "pre-commit" },
     { name = "pytest" },
     { name = "pytest-asyncio" },
+    { name = "pytest-cov" },
     { name = "pytest-mock" },
     { name = "pytest-timeout" },
     { name = "ruff" },
@@ -1297,6 +1336,7 @@ requires-dist = [
     { name = "psutil", specifier = ">=5.9.0" },
     { name = "pytest", marker = "extra == 'dev'", specifier = ">=8.3.0" },
     { name = "pytest-asyncio", marker = "extra == 'dev'", specifier = ">=1.0.0" },
+    { name = "pytest-cov", marker = "extra == 'dev'", specifier = ">=5.0.0" },
     { name = "pytest-mock", marker = "extra == 'dev'", specifier = ">=3.12.0" },
     { name = "pytest-timeout", marker = "extra == 'dev'", specifier = ">=2.2.0" },
     { name = "python-dotenv", specifier = ">=1.1.0" },


### PR DESCRIPTION
Fixes the CI workflows so they actually run on this repo's branches and gate release PRs. Both workflows triggered on `main` (unused here), so neither had ever run on a push or PR to `staging`/`production`.

## Commits

- **`6e21dcc`** — `ci.yml`: triggers `main` → `staging, production`; switch to `astral-sh/setup-uv` + `uv pip install --system`; install full `.[dev]` (was missing faker/pytest-mock/pytest-timeout/aiosqlite/pytest-cov); set `ENVIRONMENT=testing`; declare `pytest-cov`; lint + build made non-blocking given the large pre-existing ruff/mypy backlog (the **test job is the real gate**).
- **`304102c`** — `ci.yml`: `cp .env.test .env` before tests, because `config/__init__.py` validates required env vars at import time. Tests use SQLite/mocks, so no real database is needed.
- **`3fc08cd`** — `security-scan.yml`: same trigger fix; bandit exclude `./venv` → `./.venv` (the old path never matched, so it scanned the virtualenv); pip-audit + bandit made non-blocking (upload JSON reports as artifacts); **gitleaks kept as a hard gate** (currently passing — no secrets in history).

## Verification

- `ci.yml` ran green on staging: **test ✅ success** (201 passed, 1 skipped), build ✅, lint reports backlog non-blocking. Confirmed both locally and on GitHub Actions.
- `security-scan.yml` re-run triggered on this branch; advisory scanners non-blocking, gitleaks passing.

## Effect on merge

Once this lands on `production`, pushes and PRs to both branches get automated test gating + advisory security scans. (The production ruleset still gates on review, not these checks — but the signal is now real instead of never-running.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)