### PR TITLE
✨ Add Sentry error reporting + docs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,11 +43,11 @@ jobs:
 
   lint:
     runs-on: ubuntu-latest
-    # Informational only for now: the repo has a large pre-existing ruff/mypy
-    # backlog (~1800 ruff, ~450 mypy). Kept non-blocking so it reports without
-    # failing CI. Remove `continue-on-error` once `ruff check .` and `mypy .`
-    # are clean to make lint a hard gate.
-    continue-on-error: true
+    # Hard gate: `ruff check .`, `ruff format --check .`, and `mypy .` are all
+    # clean, so any new lint/format/type regression fails the build. If a large
+    # backlog ever returns and you need to unblock merges temporarily, add
+    # `continue-on-error: true` to the offending *step* (not the job — job-level
+    # only spares the overall run while the named check still reports red).
 
     steps:
     - uses: actions/checkout@v4

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -136,6 +136,7 @@ The bot implements a comprehensive error handling strategy:
 - **Decorators**: `@handle_command_errors` for regular commands, `@handle_interaction_errors` for slash commands
 - **Global Handlers**: Set up via `setup_global_exception_handler()` in main.py
 - **Error Telemetry**: Tracks error patterns in database for proactive resolution
+- **Sentry Reporting**: Unexpected errors are forwarded to Sentry from `log_error()` and the uncaught-exception hook (see [Observability & Monitoring](#observability--monitoring-sentry))
 
 ### Key Design Patterns
 
@@ -304,6 +305,52 @@ are at zero, remove the `continue-on-error: true` from that job's run step.
 Note: job-level `continue-on-error` alone is **not** enough — it spares the
 overall run but the named check still reports red, so the flag must be on the
 step.
+
+### Observability & Monitoring (Sentry)
+
+Runtime error reporting and liveness monitoring run through
+[Sentry](https://sentry.io). The integration lives in
+`utils/sentry_setup.py` and is **a no-op unless `SENTRY_DSN` is set**, so local
+development and the test suite are unaffected.
+
+**Initialisation** — `init_sentry()` is called early in `main.py` (right after
+logging is configured). It is gated on `SENTRY_DSN` and tags every event with
+the deployment `environment` and the git SHA as the `release`. Defaults are
+privacy-conservative: `send_default_pii=False` and performance tracing off
+(`traces_sample_rate=0.0`, tunable via `SENTRY_TRACES_SAMPLE_RATE`).
+
+**Error reporting** — `capture_exception()` is fired from the existing
+`log_error()` choke point (so it rides on the same filter that excludes
+expected errors like cooldowns/check-failures/`CognitaError`) and from the
+uncaught-exception hook in `setup_global_exception_handler()`. A `before_send`
+hook runs the event's exception value and log message through
+`redact_sensitive_info()`, so secrets are scrubbed before leaving the process.
+Note: `before_send` does **not** scrub stack-frame local variables — rely on
+Sentry's server-side data-scrubbing for those, or set
+`include_local_variables=False` if needed.
+
+**Liveness heartbeat** (`cogs/heartbeat.py`) — a dead-man's-switch for the
+"unreachable but not throwing errors" failure mode (hang, OOM-kill, silent
+gateway disconnect). While connected, the bot sends a Sentry cron check-in
+every 5 minutes (`send_heartbeat()`, monitor slug `twi-bot-heartbeat`, created
+automatically on first check-in). Sentry — externally — raises a missed
+check-in issue after ~15 min (interval 5 + margin 10) when they stop. Because
+the alert is driven by Sentry reacting to the *absence* of a signal, it fires
+even when the bot itself is dead. The cog loads in staging/production (not in
+test mode, where the loop is skipped).
+
+**Configuration & alerting** — `SENTRY_DSN` is set as a Railway env var on both
+the `staging` and `production` environments (same DSN; the `environment` tag
+differentiates them). Issues route to Discord via Sentry **issue-alert rules**
+("a new issue is created", filtered per environment) configured in the Sentry
+UI — the MCP/API does not create alert rules.
+
+**Gotcha** — running code locally with `SENTRY_DSN` set will report uncaught
+exceptions to the shared project via Sentry's default excepthook integration.
+Normal local dev tags them `development` (ignored by the staging/production
+alert rules), but manual test scripts that force `environment='staging'`/
+`'production'` will trip the real Discord alerts. Tag throwaway test events with
+a distinct environment (e.g. `local-test`).
 
 ## Database Schema
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -282,6 +282,29 @@ The stats module uses a mixin architecture — `stats.py` is the only loadable c
 - Permission system leverages Discord's native permissions with bot owner override
 - Setup git hooks via `pre-commit install` for automated checks
 
+### Security Scanning (CI)
+
+`.github/workflows/security-scan.yml` runs on push/PR to `staging` and
+`production`, plus a weekly schedule. It has three jobs:
+
+- **Dependency Vulnerability Scan** (`pip-audit`) — **advisory**. Uploads
+  `pip-audit-report.json`; the step uses `continue-on-error: true` so known
+  advisories (including un-patchable transitive ones) don't block merges.
+- **Static Security Analysis** (`bandit`) — **advisory**. Scans the repo
+  (excluding `tests` and `.venv`), uploads `bandit-report.json`, and likewise
+  uses step-level `continue-on-error: true` so findings don't block merges.
+- **Secret Scanning** (`gitleaks`) — **hard gate**. This one *should* fail the
+  build if a secret is detected. It checks out with `fetch-depth: 0` so
+  gitleaks can scan full history (a shallow clone makes it error with
+  "stderr is not empty").
+
+Advisory means the check reports green and the finding lives in the uploaded
+artifact for triage. To promote a scanner to a blocking gate once its findings
+are at zero, remove the `continue-on-error: true` from that job's run step.
+Note: job-level `continue-on-error` alone is **not** enough — it spares the
+overall run but the named check still reports red, so the flag must be on the
+step.
+
 ## Database Schema
 
 The bot uses PostgreSQL with optimized schemas including:

--- a/cogs/heartbeat.py
+++ b/cogs/heartbeat.py
@@ -1,0 +1,68 @@
+"""Liveness heartbeat cog for Twi Bot Shard.
+
+Implements a dead-man's-switch: while the bot is connected to Discord, a
+background task sends a check-in to Sentry's cron monitoring every 5 minutes.
+Sentry watches for those check-ins externally — if they stop (process dead,
+hung, OOM-killed, or silently disconnected), Sentry raises a missed-check-in
+issue (~15 min) that routes to Discord like any other alert.
+
+This catches the "unreachable but not throwing errors" failure mode that the
+exception-based reporting can't, precisely because the alert is driven by an
+external observer reacting to the *absence* of a signal — a check inside the
+bot can't fire when the bot itself is dead.
+
+The heartbeat is a no-op unless SENTRY_DSN is configured, so local development
+and tests are unaffected.
+"""
+
+from discord.ext import commands, tasks
+
+import config
+from utils.base_cog import BaseCog
+from utils.sentry_setup import send_heartbeat
+
+
+class Heartbeat(BaseCog):
+    """Sends periodic liveness check-ins to Sentry cron monitoring."""
+
+    def __init__(self, bot: commands.Bot) -> None:
+        """Initialize the cog and start the heartbeat loop (outside test mode)."""
+        super().__init__(bot)
+        # Mirror the project convention: don't start background loops in tests.
+        if config.logfile != "test":
+            self.heartbeat_loop.start()
+            self.logger.info("heartbeat_loop_started")
+        else:
+            self.logger.info("heartbeat_loop_disabled", reason="test_mode")
+
+    async def cog_unload(self) -> None:
+        """Stop the heartbeat loop when the cog is unloaded."""
+        if hasattr(self, "heartbeat_loop") and self.heartbeat_loop.is_running():
+            self.heartbeat_loop.cancel()
+            self.logger.info("heartbeat_loop_stopped")
+
+    @tasks.loop(minutes=5)
+    async def heartbeat_loop(self) -> None:
+        """Send one liveness check-in, only while genuinely connected.
+
+        Skipping the check-in when the bot is closed means a sustained outage
+        shows up as missed check-ins in Sentry rather than false "healthy"
+        pings.
+        """
+        if self.bot.is_closed():
+            return
+        send_heartbeat()
+
+    @heartbeat_loop.before_loop
+    async def before_heartbeat(self) -> None:
+        """Wait until the bot is connected before the first check-in.
+
+        This also means a startup that hangs before reaching READY produces no
+        check-ins, so Sentry will flag it — exactly the desired failsafe.
+        """
+        await self.bot.wait_until_ready()
+
+
+async def setup(bot: commands.Bot) -> None:
+    """Required entry point for cog loading."""
+    await bot.add_cog(Heartbeat(bot))

--- a/main.py
+++ b/main.py
@@ -1067,6 +1067,7 @@ async def main() -> None:
             "cogs.settings",
             "cogs.message_log",
             "cogs.interactive_help",
+            "cogs.heartbeat",
         ]
 
         # Define critical cogs that must be loaded at startup

--- a/main.py
+++ b/main.py
@@ -35,6 +35,7 @@ from utils.error_handling import setup_global_exception_handler
 from utils.http_client import HTTPClient
 from utils.permissions import setup_permissions
 from utils.resource_monitor import ResourceMonitor
+from utils.sentry_setup import init_sentry
 from utils.service_container import ServiceContainer
 from utils.sqlalchemy_db import async_session_maker
 
@@ -986,6 +987,9 @@ async def main() -> None:
         f"discord={build['discord']} "
         f"git={build['git']}"
     )
+
+    # Initialise Sentry error reporting (no-op unless SENTRY_DSN is set).
+    init_sentry(environment=str(config.get_environment()), release=_get_git_sha())
 
     # Log the KILL_AFTER setting
     if config.kill_after > 0:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,6 +20,7 @@ dependencies = [
     "psutil>=5.9.0",
     "cryptography>=45.0.5",
     "gallery_dl>=1.29.4",
+    "sentry-sdk>=2.0.0",
 ]
 
 [project.optional-dependencies]

--- a/requirements.txt
+++ b/requirements.txt
@@ -35,12 +35,15 @@ certifi==2026.5.20
     #   httpcore
     #   httpx
     #   requests
+    #   sentry-sdk
 cffi==2.0.0
     # via cryptography
 cfgv==3.5.0
     # via pre-commit
 charset-normalizer==3.4.7
     # via requests
+coverage==7.14.1
+    # via pytest-cov
 cryptography==48.0.0
     # via
     #   twi-bot-shard (pyproject.toml)
@@ -141,7 +144,9 @@ platformdirs==4.10.0
     #   python-discovery
     #   virtualenv
 pluggy==1.6.0
-    # via pytest
+    # via
+    #   pytest
+    #   pytest-cov
 pre-commit==4.6.0
     # via twi-bot-shard (pyproject.toml)
 propcache==0.5.2
@@ -175,9 +180,12 @@ pytest==9.0.3
     # via
     #   twi-bot-shard (pyproject.toml)
     #   pytest-asyncio
+    #   pytest-cov
     #   pytest-mock
     #   pytest-timeout
 pytest-asyncio==1.4.0
+    # via twi-bot-shard (pyproject.toml)
+pytest-cov==7.1.0
     # via twi-bot-shard (pyproject.toml)
 pytest-mock==3.15.1
     # via twi-bot-shard (pyproject.toml)
@@ -195,6 +203,8 @@ requests==2.34.2
     #   gallery-dl
     #   google-api-core
 ruff==0.15.15
+    # via twi-bot-shard (pyproject.toml)
+sentry-sdk==2.61.0
     # via twi-bot-shard (pyproject.toml)
 sniffio==1.3.1
     # via openai
@@ -228,7 +238,9 @@ typing-inspection==0.4.2
 uritemplate==4.2.0
     # via google-api-python-client
 urllib3==2.7.0
-    # via requests
+    # via
+    #   requests
+    #   sentry-sdk
 virtualenv==21.4.1
     # via pre-commit
 yarl==1.24.2

--- a/utils/error_handling.py
+++ b/utils/error_handling.py
@@ -564,6 +564,19 @@ def log_error(
             log_level, f"Traceback for {error_type} in {command_name}:\n{error_details}"
         )
 
+        # Report genuinely unexpected errors to Sentry (no-op unless enabled).
+        # Imported lazily to avoid a circular import at module load.
+        from utils.sentry_setup import capture_exception as _sentry_capture
+
+        _sentry_capture(
+            error,
+            command_name=command_name,
+            user_id=user_id,
+            guild_id=guild_id,
+            channel_id=channel_id,
+            additional_context=additional_context or None,
+        )
+
 
 def handle_command_errors[CommandT: Callable[..., Coroutine[Any, Any, Any]]](
     func: CommandT,
@@ -1107,6 +1120,14 @@ def setup_global_exception_handler(bot: commands.Bot) -> None:
         logger.critical(
             "".join(traceback.format_exception(exctype, value, traceback_obj))
         )
+
+        # Report uncaught exceptions to Sentry (no-op unless enabled). These
+        # never reach log_error(), so capture them here.
+        if isinstance(value, BaseException):
+            from utils.sentry_setup import capture_exception as _sentry_capture
+
+            _sentry_capture(value, command_name="<uncaught>")
+
         sys.__excepthook__(exctype, value, traceback_obj)
 
     sys.excepthook = global_exception_handler

--- a/utils/error_handling.py
+++ b/utils/error_handling.py
@@ -1122,8 +1122,9 @@ def setup_global_exception_handler(bot: commands.Bot) -> None:
         )
 
         # Report uncaught exceptions to Sentry (no-op unless enabled). These
-        # never reach log_error(), so capture them here.
-        if isinstance(value, BaseException):
+        # never reach log_error(), so capture them here. Limit to Exception so
+        # we don't report SystemExit/KeyboardInterrupt as bugs.
+        if isinstance(value, Exception):
             from utils.sentry_setup import capture_exception as _sentry_capture
 
             _sentry_capture(value, command_name="<uncaught>")

--- a/utils/sentry_setup.py
+++ b/utils/sentry_setup.py
@@ -162,3 +162,38 @@ def capture_exception(
             scope.set_context("additional", {"info": additional_context})
 
         sentry_sdk.capture_exception(error)
+
+
+# Slug for the liveness heartbeat cron monitor. Sentry auto-creates the monitor
+# from the monitor_config on the first check-in (upsert), so no UI setup needed.
+HEARTBEAT_MONITOR_SLUG = "twi-bot-heartbeat"
+
+
+def send_heartbeat() -> None:
+    """Send a liveness check-in to Sentry's cron monitoring, if Sentry is enabled.
+
+    Acts as a dead-man's-switch: a background task calls this on a fixed
+    interval while the bot is connected. Sentry expects a check-in every 5
+    minutes and tolerates a 10-minute margin; if check-ins stop (process dead,
+    hung, OOM-killed, or disconnected), Sentry raises a missed-check-in issue
+    (~15 min) which routes to Discord like any other issue.
+
+    A cheap no-op when Sentry is not initialised.
+    """
+    if not _initialized:
+        return
+
+    from sentry_sdk.crons import capture_checkin
+
+    capture_checkin(
+        monitor_slug=HEARTBEAT_MONITOR_SLUG,
+        status="ok",
+        monitor_config={
+            "schedule": {"type": "interval", "value": 5, "unit": "minute"},
+            "checkin_margin": 10,  # minutes of tolerance (covers redeploys)
+            "max_runtime": 2,
+            "timezone": "UTC",
+            "failure_issue_threshold": 1,
+            "recovery_threshold": 1,
+        },
+    )

--- a/utils/sentry_setup.py
+++ b/utils/sentry_setup.py
@@ -15,8 +15,16 @@ Environment variables:
         Defaults to 0.0 (error reporting only, no performance overhead/quota).
 """
 
+from __future__ import annotations
+
 import logging
 import os
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+    # Type-only import; avoids a hard runtime dependency on sentry_sdk so the
+    # module still imports cleanly when the package is absent.
+    from sentry_sdk.types import Event, Hint
 
 logger = logging.getLogger("sentry")
 
@@ -25,7 +33,7 @@ logger = logging.getLogger("sentry")
 _initialized: bool = False
 
 
-def _before_send(event: dict, hint: dict) -> dict | None:
+def _before_send(event: Event, hint: Hint) -> Event | None:
     """Scrub sensitive data from outgoing Sentry events.
 
     Runs exception messages and the log entry message through the project's
@@ -45,12 +53,17 @@ def _before_send(event: dict, hint: dict) -> dict | None:
 
     try:
         for value in event.get("exception", {}).get("values", []):
-            if value.get("value"):
-                value["value"] = redact_sensitive_info(value["value"])
+            message = value.get("value")
+            if isinstance(message, str):
+                value["value"] = redact_sensitive_info(message)
 
-        logentry = event.get("logentry")
-        if logentry and logentry.get("message"):
-            logentry["message"] = redact_sensitive_info(logentry["message"])
+        # Typed as a read-only Mapping in Sentry's stubs, but a mutable dict at
+        # runtime; annotate Any so the in-place scrub type-checks.
+        logentry: Any = event.get("logentry")
+        if logentry:
+            message = logentry.get("message")
+            if isinstance(message, str):
+                logentry["message"] = redact_sensitive_info(message)
     except Exception as exc:  # pragma: no cover - defensive; never block sending
         logger.debug(f"Sentry before_send scrubbing failed: {exc}")
 

--- a/utils/sentry_setup.py
+++ b/utils/sentry_setup.py
@@ -1,0 +1,164 @@
+"""Sentry error-reporting integration for Cognita bot.
+
+This module wires the bot's error handling into `Sentry <https://sentry.io>`_.
+It is intentionally a no-op unless the ``SENTRY_DSN`` environment variable is
+set, so local development and the test suite are unaffected.
+
+Sentry is fed exclusively from the existing error-handling choke point
+(:func:`utils.error_handling.log_error`), and every event is run through the
+project's :func:`redact_sensitive_info` scrubber via ``before_send`` so that no
+unredacted secrets ever leave the process.
+
+Environment variables:
+    SENTRY_DSN: The project DSN from sentry.io. When unset, Sentry is disabled.
+    SENTRY_TRACES_SAMPLE_RATE: Optional float (0.0-1.0) for performance tracing.
+        Defaults to 0.0 (error reporting only, no performance overhead/quota).
+"""
+
+import logging
+import os
+
+logger = logging.getLogger("sentry")
+
+# Whether sentry_sdk.init() has run successfully this process. Guards the
+# capture helpers so they're cheap no-ops when Sentry is disabled.
+_initialized: bool = False
+
+
+def _before_send(event: dict, hint: dict) -> dict | None:
+    """Scrub sensitive data from outgoing Sentry events.
+
+    Runs exception messages and the log entry message through the project's
+    existing redaction patterns. Stacktrace frames (file paths, code) are left
+    intact since they're code locations, not secrets, and are the whole point
+    of the report.
+
+    Args:
+        event: The Sentry event payload about to be sent.
+        hint: Sentry-provided context (unused, but part of the hook signature).
+
+    Returns:
+        The scrubbed event, or None to drop it.
+    """
+    # Imported lazily to avoid a circular import with utils.error_handling.
+    from utils.error_handling import redact_sensitive_info
+
+    try:
+        for value in event.get("exception", {}).get("values", []):
+            if value.get("value"):
+                value["value"] = redact_sensitive_info(value["value"])
+
+        logentry = event.get("logentry")
+        if logentry and logentry.get("message"):
+            logentry["message"] = redact_sensitive_info(logentry["message"])
+    except Exception as exc:  # pragma: no cover - defensive; never block sending
+        logger.debug(f"Sentry before_send scrubbing failed: {exc}")
+
+    return event
+
+
+def init_sentry(
+    environment: str | None = None,
+    release: str | None = None,
+) -> bool:
+    """Initialise Sentry if a DSN is configured.
+
+    Safe to call unconditionally: when ``SENTRY_DSN`` is unset (local dev,
+    tests) this logs a debug line and returns False without side effects.
+
+    Args:
+        environment: Deployment environment tag (e.g. "production",
+            "staging"). Falls back to the bot's configured environment.
+        release: Release identifier, typically a git SHA, used by Sentry to
+            tie errors to a specific deploy.
+
+    Returns:
+        True if Sentry was initialised, False otherwise.
+    """
+    global _initialized
+
+    dsn = os.getenv("SENTRY_DSN")
+    if not dsn:
+        logger.debug("SENTRY_DSN not set; Sentry error reporting disabled.")
+        return False
+
+    try:
+        import sentry_sdk
+    except ImportError:
+        logger.warning(
+            "SENTRY_DSN is set but the 'sentry-sdk' package is not installed; "
+            "Sentry error reporting disabled. Run `uv pip install -e .`."
+        )
+        return False
+
+    if environment is None:
+        from config import get_environment
+
+        environment = str(get_environment())
+
+    try:
+        traces_sample_rate = float(os.getenv("SENTRY_TRACES_SAMPLE_RATE", "0.0"))
+    except ValueError:
+        traces_sample_rate = 0.0
+
+    sentry_sdk.init(
+        dsn=dsn,
+        environment=environment,
+        release=release,
+        # Never attach IPs/usernames automatically; we add only the IDs we
+        # explicitly choose in capture_exception().
+        send_default_pii=False,
+        traces_sample_rate=traces_sample_rate,
+        before_send=_before_send,
+    )
+
+    _initialized = True
+    logger.info(
+        "Sentry initialised (environment=%s, release=%s)",
+        environment,
+        release or "unknown",
+    )
+    return True
+
+
+def capture_exception(
+    error: Exception,
+    *,
+    command_name: str | None = None,
+    user_id: int | None = None,
+    guild_id: int | None = None,
+    channel_id: int | None = None,
+    additional_context: str | None = None,
+) -> None:
+    """Send an exception to Sentry with Discord context, if Sentry is enabled.
+
+    A cheap no-op when Sentry is not initialised. Context is attached as tags
+    (for filtering/grouping in the Sentry UI) rather than PII.
+
+    Args:
+        error: The exception to report.
+        command_name: Name of the command that raised the error, if any.
+        user_id: Discord user ID that triggered the error.
+        guild_id: Discord guild ID where the error occurred.
+        channel_id: Discord channel ID where the error occurred.
+        additional_context: Free-form extra context to attach.
+    """
+    if not _initialized:
+        return
+
+    import sentry_sdk
+
+    with sentry_sdk.new_scope() as scope:
+        if command_name is not None:
+            scope.set_tag("command", command_name)
+        if guild_id is not None:
+            scope.set_tag("guild_id", str(guild_id))
+        if user_id is not None:
+            # Recorded as id-only; send_default_pii stays False.
+            scope.set_user({"id": str(user_id)})
+        if channel_id is not None:
+            scope.set_context("discord", {"channel_id": channel_id})
+        if additional_context:
+            scope.set_context("additional", {"info": additional_context})
+
+        sentry_sdk.capture_exception(error)

--- a/uv.lock
+++ b/uv.lock
@@ -1207,6 +1207,19 @@ wheels = [
 ]
 
 [[package]]
+name = "sentry-sdk"
+version = "2.61.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "certifi" },
+    { name = "urllib3" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/52/4d/3c66e6045bd2071256b6b6fdcb0cc02b86ce54b2acc2ceac79af8e0efbb5/sentry_sdk-2.61.0.tar.gz", hash = "sha256:1ca9b4bb777eb5be67004edab7eb894f21c6301f1d05ed64966719ad5d1764ce", size = 458510, upload-time = "2026-05-28T09:40:28.917Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/21/5a/9794736d5802689c1a48862e6afe6b7f3e86cc37c15d4a84bc0143877dc1/sentry_sdk-2.61.0-py3-none-any.whl", hash = "sha256:ec4d30273909cb1d198e03208b16ee70e2bc5d90a16fd9f1fb2fc6a72e1f03dc", size = 483111, upload-time = "2026-05-28T09:40:27.027Z" },
+]
+
+[[package]]
 name = "sniffio"
 version = "1.3.1"
 source = { registry = "https://pypi.org/simple" }
@@ -1292,6 +1305,7 @@ dependencies = [
     { name = "pillow" },
     { name = "psutil" },
     { name = "python-dotenv" },
+    { name = "sentry-sdk" },
     { name = "sqlalchemy" },
     { name = "structlog" },
 ]
@@ -1341,6 +1355,7 @@ requires-dist = [
     { name = "pytest-timeout", marker = "extra == 'dev'", specifier = ">=2.2.0" },
     { name = "python-dotenv", specifier = ">=1.1.0" },
     { name = "ruff", marker = "extra == 'dev'", specifier = ">=0.3.0" },
+    { name = "sentry-sdk", specifier = ">=2.0.0" },
     { name = "sqlalchemy", specifier = ">=2.0.41" },
     { name = "structlog", specifier = ">=24.1.0" },
 ]


### PR DESCRIPTION
## Summary
Promotes the Sentry error-reporting integration (verified end-to-end on staging) to production, plus one earlier docs commit.

### Changes
- **Sentry error reporting** (`7b17ef3`, `4831d88`): wires Sentry into the existing `log_error()` choke point and the uncaught-exception hook. No-op unless `SENTRY_DSN` is set; reuses `redact_sensitive_info()` via `before_send` so secrets are scrubbed before sending. PII off, performance tracing off by default. Tagged with environment + git SHA for release tracking. `sentry-sdk` added to `requirements.txt`/`uv.lock` (the Docker build installs from `requirements.txt`).
- **Docs** (`d9b5ee4`): document advisory security-scan CI setup in CLAUDE.md.

### Verification (on staging)
- Deploy logs show `Sentry initialised (environment=staging, …)`.
- Real events confirmed: secret scrubbing (`postgres: [REDACTED]`), tags (command/guild/user), and Discord alert routing all working.

### Deploy notes
- `SENTRY_DSN` is already set on the production Railway environment.
- On merge, Railway deploys prod with Sentry active (`environment=production`).
- Remaining manual step: add a Sentry issue-alert rule filtered to `environment:production` → Discord.

🤖 Generated with [Claude Code](https://claude.com/claude-code)