### PR TITLE
🐛 fix: missing roles.permissions column & verified-role guard

### DIFF
--- a/cogs/mods.py
+++ b/cogs/mods.py
@@ -337,6 +337,12 @@ class ModCogs(commands.Cog):
                 tzinfo=None
             ) < datetime.datetime.now() - datetime.timedelta(hours=72):
                 verified = member.guild.get_role(945388135355924571)
+                if verified is None:
+                    logging.warning(
+                        "filter_new_users: verified role 945388135355924571 not found in guild %s; skipping",
+                        member.guild.id,
+                    )
+                    return
                 await member.add_roles(verified)
         except Exception as e:
             # Use standardized error logging with context

--- a/database/init.sql
+++ b/database/init.sql
@@ -91,6 +91,7 @@ CREATE TABLE IF NOT EXISTS roles
     hoisted         boolean,
     managed         boolean,
     position        integer,
+    permissions     bigint,
     guild_id        bigint
         CONSTRAINT roles_servers_server_id_fk REFERENCES servers,
     deleted         boolean DEFAULT false,

--- a/database/schema/migrations/20260531_add_roles_permissions.sql
+++ b/database/schema/migrations/20260531_add_roles_permissions.sql
@@ -1,0 +1,17 @@
+-- Migration: add missing `permissions` column to `roles`
+-- Date: 2026-05-31
+--
+-- Context:
+--   cogs/stats_listeners.py persists Discord role permission bitfields
+--   (`role.permissions.value`) on role create (guild_role_create) and role
+--   update (enhanced_guild_role_update), but the column was never present in
+--   the schema/model. Every role create/update therefore raised:
+--     column "permissions" of relation "roles" does not exist
+--   (Sentry: PYTHON-AIOHTTP-3 / -5 / -6).
+--
+-- Discord permission values are a 64-bit bitfield, so `bigint` is sufficient
+-- and consistent with the other id/bitfield columns on this table. Nullable
+-- so existing rows are unaffected.
+
+ALTER TABLE roles
+    ADD COLUMN IF NOT EXISTS permissions bigint;

--- a/models/tables/role.py
+++ b/models/tables/role.py
@@ -28,6 +28,9 @@ class Role(Base):
     hoisted: Mapped[bool | None] = mapped_column(Boolean, nullable=True, default=None)
     managed: Mapped[bool | None] = mapped_column(Boolean, nullable=True, default=None)
     position: Mapped[int | None] = mapped_column(Integer, nullable=True, default=None)
+    permissions: Mapped[int | None] = mapped_column(
+        BigInteger, nullable=True, default=None
+    )
     guild_id: Mapped[int | None] = mapped_column(
         BigInteger, nullable=True, default=None
     )

--- a/tests/test_mods_cog_unit.py
+++ b/tests/test_mods_cog_unit.py
@@ -306,6 +306,32 @@ class TestFilterNewUsersListener:
         # Verify role was NOT added
         member.add_roles.assert_not_called()
 
+    @pytest.mark.asyncio
+    async def test_filter_new_users_skips_when_verified_role_missing(self) -> None:
+        """Test that a missing verified role is skipped instead of crashing.
+
+        Regression: get_role() returning None previously caused add_roles(None)
+        to raise "'NoneType' object has no attribute 'id'".
+        """
+        bot = await TestSetup.create_test_bot()
+        cog = ModCogs(bot)
+
+        guild = MockGuildFactory.create()
+        # Verified role does not exist in the guild
+        guild.get_role = MagicMock(return_value=None)
+
+        # Create member with old account (would otherwise be verified)
+        member = MockMemberFactory.create()
+        member.guild = guild
+        old_date = datetime.now(UTC) - timedelta(hours=100)
+        member.created_at = old_date.replace(tzinfo=UTC)
+        member.add_roles = AsyncMock()
+
+        await cog.filter_new_users(member)
+
+        # No role added, no exception raised
+        member.add_roles.assert_not_called()
+
 
 class TestModsEdgeCases:
     """Tests for edge cases and error handling."""


### PR DESCRIPTION
## Summary

Fixes two latent crashes surfaced in Sentry (5 issues, two root causes).

### 1. Missing `roles.permissions` column (PYTHON-AIOHTTP-3, -5, -6)
`cogs/stats_listeners.py` persists `role.permissions.value` on role create (`guild_role_create`) and role update (`enhanced_guild_role_update`), but the column never existed in the schema/model. Every role create/update raised:
> column "permissions" of relation "roles" does not exist

**Fix** (intent-preserving — keep tracking permissions):
- Added `permissions: Mapped[int | None]` to `models/tables/role.py`
- Added `permissions bigint` to `database/init.sql`
- Added migration `database/schema/migrations/20260531_add_roles_permissions.sql`
- Applied to **staging + production** DBs (verified)

### 2. `filter_new_users` NoneType crash (PYTHON-AIOHTTP-2, -4)
`cogs/mods.py` called `member.add_roles(verified)` where `verified` is `None` when the hardcoded verified-role id isn't present in the guild, raising:
> 'NoneType' object has no attribute 'id'

**Fix:** guard against the missing role (log a warning and return). Added a regression test.

## Verification
- `ruff check` on changed files — clean
- `tests/test_mods_cog_unit.py` — 11 passed (incl. new `test_filter_new_users_skips_when_verified_role_missing`)
- Both live DBs already carry the column

## Deploy note
The production DB column is **already applied**, so no manual migration step is needed before this merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)