### PR TITLE
🐛 fix(decorators): restore handle_errors decorator (fix CI test collection)

### DIFF
--- a/utils/decorators.py
+++ b/utils/decorators.py
@@ -1,11 +1,12 @@
 """Decorators for Twi Bot Shard.
 
 This module provides decorators for cross-cutting concerns like command-usage
-logging (``log_command``) and permission checks (``require_bot_channel``,
-``require_admin``).
+logging (``log_command``), command error handling (``handle_errors``), and
+permission checks (``require_bot_channel``, ``require_admin``).
 
-For error handling, use ``handle_command_errors`` / ``handle_interaction_errors``
-from :mod:`utils.error_handling` instead.
+``handle_errors`` delegates to the cog's own ``handle_error`` method; for the
+standard, fully-featured handling prefer ``handle_command_errors`` /
+``handle_interaction_errors`` from :mod:`utils.error_handling`.
 """
 
 import functools
@@ -42,6 +43,41 @@ def log_command(command_name: str | None = None) -> Callable[[CommandT], Command
 
             # Call the original function with all arguments
             return await func(self, *args, **kwargs)
+
+        return cast(CommandT, wrapper)
+
+    return decorator
+
+
+def handle_errors(command_name: str | None = None) -> Callable[[CommandT], CommandT]:
+    """Decorator to handle command errors.
+
+    Catches exceptions raised by the wrapped command and delegates them to the
+    cog's ``handle_error(ctx_or_interaction, error, command_name)`` method, which
+    the cog must provide. For the standard, fully-featured error handling, prefer
+    ``handle_command_errors`` / ``handle_interaction_errors`` from
+    :mod:`utils.error_handling`.
+
+    Args:
+        command_name: Optional name for the command. If not provided, the function name will be used.
+
+    Returns:
+        A decorator that handles command errors.
+    """
+
+    def decorator(func: CommandT) -> CommandT:
+        cmd_name = command_name or func.__name__
+
+        @functools.wraps(func)
+        async def wrapper(
+            self: Any, ctx_or_interaction: Any, *args: Any, **kwargs: Any
+        ) -> Any:
+            try:
+                # Call the original function
+                return await func(self, ctx_or_interaction, *args, **kwargs)
+            except Exception as e:
+                # Delegate to the cog's handle_error method
+                await self.handle_error(ctx_or_interaction, e, cmd_name)
 
         return cast(CommandT, wrapper)
 


### PR DESCRIPTION
The documentation-audit PR (#37) removed the `handle_errors` decorator from `utils/decorators.py` as "unused and broken". That was incorrect: it is part of the **tested public API** — `tests/test_decorators.py` and `tests/test_property_based.py` import it and assert it delegates to the cog's `handle_error` method.

Removing it broke **test collection** (`ImportError` → pytest exit code 2), which is why the `test` job on PR #38 failed in ~20s.

This restores the decorator (with a clearer docstring documenting that it delegates to the cog's own `handle_error`, and that `handle_command_errors`/`handle_interaction_errors` are the preferred standard handlers).

## Verification
- Full suite: **202 passed, 1 skipped** (collection clean, 203 collected)
- `ruff check` ✅ · `ruff format --check` ✅ · `mypy` ✅ on `utils/decorators.py`
- `tests/test_decorators.py` + `tests/test_property_based.py`: 11 passed

Once merged, PR #38 (staging → production) will re-run CI and should be green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)