### PR TITLE
🐛 fix(errors): exclude CommandNotFound from Sentry escalation

### DIFF
--- a/utils/error_handling.py
+++ b/utils/error_handling.py
@@ -555,7 +555,9 @@ def log_error(
             commands.CommandOnCooldown
             | discord.app_commands.errors.CommandOnCooldown
             | commands.CheckFailure
-            | discord.app_commands.errors.CheckFailure,
+            | discord.app_commands.errors.CheckFailure
+            | commands.CommandNotFound
+            | discord.app_commands.errors.CommandNotFound,
         )
     ):
         error_details = "".join(


### PR DESCRIPTION
## Summary

Fixes Sentry issue [PYTHON-AIOHTTP-D](https://willhalloward.sentry.io/issues/PYTHON-AIOHTTP-D) — `CommandNotFound: Command "!!" is not found`.

`CommandNotFound` is expected noise: it fires whenever a user types something prefixed like a command that isn't one (here, `!!`). The `unknown_admin_command` path in `on_command_error` already logs it at DEBUG level, **but** the explicit `capture_exception()` call inside `log_error()` is gated only on exception *type*, not log level — and `CommandNotFound` wasn't in the exclusion list. So these were still being escalated to Sentry as `error`-level events.

## Change

Added `commands.CommandNotFound` and `discord.app_commands.errors.CommandNotFound` to the expected-error exclusion filter in `utils/error_handling.py`, alongside the existing cooldown and check-failure exclusions. This suppresses both the full-traceback log and the Sentry capture for these expected errors.

User-facing behavior is unchanged (no error message shown, telemetry still tracked via `track_error`).

## Verification

- Confirmed both `CommandNotFound` types resolve in the installed discord.py.
- File parses cleanly.

The existing Sentry issue will be resolved manually once this reaches live.

🤖 Generated with [Claude Code](https://claude.com/claude-code)