### PR TITLE
🔧 fix(ci): repair security-scan jobs and silence Node 20 deprecation

### DIFF
--- a/.github/workflows/security-scan.yml
+++ b/.github/workflows/security-scan.yml
@@ -17,10 +17,10 @@ jobs:
     # failing the workflow; flip off once findings are triaged to zero.
     continue-on-error: true
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: '3.12'
 
@@ -31,12 +31,15 @@ jobs:
 
       - name: Run pip-audit
         # Advisory: don't fail the check on known advisories; report via artifact.
+        # `--desc on` must take an explicit value — `--desc .` makes argparse
+        # consume the project path as the flag's value and abort with exit 2,
+        # so the scan never runs. Pass the project path positionally instead.
         continue-on-error: true
-        run: pip-audit -f json -o pip-audit-report.json --desc .
+        run: pip-audit --desc on -f json -o pip-audit-report.json .
 
       - name: Upload pip-audit report
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: pip-audit-report
           path: pip-audit-report.json
@@ -48,10 +51,10 @@ jobs:
     # without failing the workflow.
     continue-on-error: true
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: '3.12'
 
@@ -70,7 +73,7 @@ jobs:
 
       - name: Upload Bandit report
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: bandit-report
           path: bandit-report.json
@@ -81,7 +84,7 @@ jobs:
     # Hard gate: secret detection should block. Currently passing (no secrets
     # in history).
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           # Full history so gitleaks can scan all commits; a shallow clone
           # makes git emit to stderr and gitleaks errors with
@@ -89,6 +92,6 @@ jobs:
           fetch-depth: 0
 
       - name: Run Gitleaks
-        uses: gitleaks/gitleaks-action@v2
+        uses: gitleaks/gitleaks-action@v3
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/scripts/schema/query_faiss_schema.py
+++ b/scripts/schema/query_faiss_schema.py
@@ -55,7 +55,7 @@ def build_prompt(
         context_info += "- When users ask about 'this server' or 'here', they are referring to the Server ID above\n"
         context_info += "- When users ask about 'this channel', they are referring to the Channel ID above\n"
 
-    return f"""  # nosec B608 - this is an LLM prompt string, not an executed query
+    return f"""
 You are a PostgreSQL SQL query generator for Cognita, a Discord bot that helps users interact with their Discord server data.
 
 Context:
@@ -80,7 +80,7 @@ Available Schema Information:
 
 User Question (from Discord):
 \"\"\"{question}\"\"\"
-"""
+"""  # nosec B608 - this is an LLM prompt string, not an executed query
 
 
 def generate_sql(prompt: str) -> str:

--- a/utils/schema_search.py
+++ b/utils/schema_search.py
@@ -159,7 +159,7 @@ def build_sql_prompt(
         context_info += "- When users ask about 'this server' or 'here', they are referring to the Server ID above\n"
         context_info += "- When users ask about 'this channel', they are referring to the Channel ID above\n"
 
-    return f"""  # nosec B608 - this is an LLM prompt string, not an executed query
+    return f"""
 You are a PostgreSQL SQL query generator for Cognita, a Discord bot that helps users interact with their Discord server data.
 
 Context:
@@ -184,7 +184,7 @@ Available Schema Information:
 
 User Question (from Discord):
 \"\"\"{question}\"\"\"
-"""
+"""  # nosec B608 - this is an LLM prompt string, not an executed query
 
 
 async def generate_sql(


### PR DESCRIPTION
## Summary

Fixes the "2 errors + 4 warnings" surfaced by the **Security Scanning** workflow. None represented an actual vulnerability — they were a broken command, broken suppressions, and deprecated action runtimes.

## Issues fixed

### 1. Dependency Vulnerability Scan — exit code 2 (scan never ran)
The command `pip-audit -f json -o pip-audit-report.json --desc .` is malformed: `--desc` expects `on`/`off`/`auto`, so argparse consumed the `.` project path as the flag's value and aborted with exit 2 **before scanning** — which is also why the run logged *"No files were found with the provided path: pip-audit-report.json"*.

Fixed to `pip-audit --desc on -f json -o pip-audit-report.json .`. The scan now runs and reports **0 vulnerabilities**.

### 2. Static Security Analysis — exit code 1 (Bandit B608 ×2)
`utils/schema_search.py` and `scripts/schema/query_faiss_schema.py` both had a `# nosec B608` placed *after* the opening `f"""`, which put it **inside the string literal**. Two consequences:
- Bandit never saw the suppression, so it kept flagging both.
- The literal text `# nosec B608 - this is an LLM prompt string...` was leaking into the prompt sent to the LLM.

Moved each `# nosec B608` to the closing `"""` line, where Bandit honors it. These strings are LLM prompts, not executed SQL, so the suppression is correct. Bandit now reports **0 findings** and the prompt bodies are clean.

### 3. Node.js 20 deprecation warnings (×4)
GitHub force-removes Node 20 action runtimes on **2026-06-16**. Bumped to current major versions (all run on Node 24):
- `actions/checkout` v4 → v6
- `actions/setup-python` v5 → v6
- `actions/upload-artifact` v4 → v7
- `gitleaks/gitleaks-action` v2 → v3

## Verification
- `bandit -r . -x ./tests,./.venv` → 0 findings, exit 0
- `pip-audit --desc on ... .` → 0 vulnerabilities, exit 0
- Both Python files parse and pass `ruff format --check`
- Workflow YAML validates

🤖 Generated with [Claude Code](https://claude.com/claude-code)