### PR TITLE
🔇 fix(ao3): don't Sentry-alert on transient, self-healing login retries

### DIFF
--- a/cogs/external_services.py
+++ b/cogs/external_services.py
@@ -85,19 +85,27 @@ class ExternalServices(BaseCog, name="ExternalServices"):  # type: ignore[call-a
                     return
 
                 except Exception as e:
-                    self.logger.error(
-                        f"AO3 login failed (attempt {attempt}/{max_retries}): {e}",
-                        exc_info=True,
-                    )
-
                     if attempt < max_retries:
+                        # Transient AO3 flakiness — e.g. the login page comes
+                        # back without an authenticity_token, which surfaces as
+                        # a TypeError deep in the AO3 lib. The retry loop almost
+                        # always recovers, so keep this at WARNING: it stays in
+                        # the logs (as a Sentry breadcrumb) but does NOT raise a
+                        # Sentry issue for a failure we self-heal from.
                         wait_time = 2**attempt
-                        self.logger.info(
-                            f"Retrying AO3 login in {wait_time} seconds..."
+                        self.logger.warning(
+                            f"AO3 login attempt {attempt}/{max_retries} failed "
+                            f"({type(e).__name__}: {e}); retrying in {wait_time}s"
                         )
                         await asyncio.sleep(wait_time)
                     else:
-                        self.logger.error("AO3 login failed after all retry attempts")
+                        # All retries exhausted and no cached session was
+                        # usable — AO3 features are now degraded, so this one is
+                        # genuinely Sentry-worthy.
+                        self.logger.error(
+                            f"AO3 login failed after {max_retries} attempts: {e}",
+                            exc_info=True,
+                        )
                         self.ao3_login_successful = False
         finally:
             self.ao3_login_in_progress = False


### PR DESCRIPTION
## Summary

Silences the regressed Sentry issue [PYTHON-AIOHTTP-9](https://willhalloward.sentry.io/issues/PYTHON-AIOHTTP-9) (`AO3 login failed: 'NoneType' object is not subscriptable`) without weakening real outage alerting.

## Investigation

The AO3 **session-blob cache** (added in `eec6196`) is deployed and working — staging's `ao3_sessions` table holds a fresh authed session, and it's rehydrated + probed on startup so we usually skip login entirely. The alert was **not** a sign that feature is broken.

On a genuine cache miss (cold start, >7d stale, or a failed auth probe), the code falls back to a fresh `AO3.Session(user, pass)` login. That login intermittently fails on **attempt 1** when AO3 returns a login page without an `authenticity_token` input — `soup.find(...)` is `None` and `[...]["value"]` raises `TypeError` inside the AO3 library. The retry loop then succeeds (the 18:29 incident: attempt 1 failed at 18:29:19, blob saved at 18:29:24).

The bug: **every** failed attempt was logged at `logger.error(..., exc_info=True)`, and Sentry's `LoggingIntegration` turns any ERROR log into an issue — so a transient failure the retry loop *immediately recovered from* raised an alert anyway. All 8 occurrences were self-healed retries, not real outages.

## Change

In `_initialize_ao3_session`:
- **Intermediate** failed attempts → `WARNING` (still logged, kept as a Sentry breadcrumb, but no issue raised).
- **Final** failure after all retries exhausted → stays `ERROR` with `exc_info` (genuinely Sentry-worthy: AO3 features are degraded and no cached session is usable).

No behavioral change to the retry/backoff logic or the cache path — only the log level of recoverable attempts.

## Verification
- `ruff check` / `ruff format --check` pass
- File parses

After merge, [PYTHON-AIOHTTP-9](https://willhalloward.sentry.io/issues/PYTHON-AIOHTTP-9) can be resolved; it will only reopen if AO3 login fails through all retries with no usable cached session.

🤖 Generated with [Claude Code](https://claude.com/claude-code)