### PR TITLE
🐛 fix(interactions): defer /role and /repost; squash 10062 timeout cascade

### DIFF
--- a/cogs/gallery.py
+++ b/cogs/gallery.py
@@ -276,6 +276,12 @@ class GalleryCog(BaseCog, name="Gallery & Mementos"):  # type: ignore[call-arg] 
             interaction: The Discord interaction
             message: The message to analyze for repostable content
         """
+        # Acknowledge immediately; analyzing the message and building the menu can
+        # run past Discord's 3-second window and 404 with 10062 (Unknown interaction).
+        # The menu is then surfaced via edit_original_response so it stays the
+        # "original response" that delete_original_response() can later remove.
+        await interaction.response.defer()
+
         repost_type = []
 
         # Check for attachments
@@ -302,7 +308,7 @@ class GalleryCog(BaseCog, name="Gallery & Mementos"):  # type: ignore[call-arg] 
                     "message_id": message.id,
                 },
             )
-            await interaction.response.send_message(
+            await interaction.followup.send(
                 "❌ Error analyzing message content. Please try again.", ephemeral=True
             )
             return
@@ -431,7 +437,9 @@ class GalleryCog(BaseCog, name="Gallery & Mementos"):  # type: ignore[call-arg] 
             )
 
             try:
-                await interaction.response.send_message(embed=embed, view=view)
+                # We deferred above, so the menu becomes the (now-acknowledged)
+                # original response via edit rather than a fresh send_message.
+                await interaction.edit_original_response(embed=embed, view=view)
             except discord.HTTPException as e:
                 self.logger.error(
                     f"Failed to send repost menu: {e}",
@@ -441,7 +449,7 @@ class GalleryCog(BaseCog, name="Gallery & Mementos"):  # type: ignore[call-arg] 
                         "guild_id": interaction.guild_id,
                     },
                 )
-                await interaction.response.send_message(
+                await interaction.followup.send(
                     "❌ Failed to display repost options. Please try again.",
                     ephemeral=True,
                 )

--- a/cogs/roles.py
+++ b/cogs/roles.py
@@ -577,6 +577,11 @@ class Roles(commands.Cog, name="Roles"):  # type: ignore[call-arg]  # stub
     async def role(self, interaction: discord.Interaction, role: discord.Role) -> None:
         """Add or remove a self-assignable role from yourself."""
         try:
+            # Acknowledge immediately so the DB lookups and role edits below can't
+            # run past Discord's 3-second interaction window and 404 with
+            # 10062 (Unknown interaction). Buys a 15-minute followup window.
+            await interaction.response.defer()
+
             if not role:
                 raise ValidationError(message="Role parameter is required")
 
@@ -709,7 +714,7 @@ class Roles(commands.Cog, name="Roles"):  # type: ignore[call-arg]  # stub
                 embed.add_field(name="Category", value=s_role["category"], inline=True)
 
             embed.set_footer(text=f"Action: {action.title()}")
-            await interaction.response.send_message(embed=embed)
+            await interaction.followup.send(embed=embed)
 
         except (ValidationError, PermissionError, DatabaseError, ExternalServiceError):
             raise

--- a/utils/error_handling.py
+++ b/utils/error_handling.py
@@ -712,6 +712,17 @@ def handle_interaction_errors[CommandT: Callable[..., Coroutine[Any, Any, Any]]]
                     await interaction.response.send_message(
                         user_message, ephemeral=ephemeral
                     )
+            except discord.HTTPException as e:
+                # Only 10062 (Unknown interaction) is expected here: the token already
+                # expired, so there is no live interaction left to deliver the error
+                # reply to. That is planned fallout from an already-reported primary
+                # error, not a new fault — quietly skip it. Any other delivery failure
+                # is unexpected and must still escalate (the primary error, including a
+                # genuine timeout, is reported separately via log_error below).
+                if getattr(e, "code", None) == 10062:
+                    logger.debug(f"Skipped error reply; interaction already gone: {e}")
+                else:
+                    logger.error(f"Failed to send error message to user: {e}")
             except Exception as e:
                 logger.error(f"Failed to send error message to user: {e}")
 
@@ -1071,6 +1082,17 @@ async def handle_global_app_command_error(
             await interaction.followup.send(user_message, ephemeral=ephemeral)
         else:
             await interaction.response.send_message(user_message, ephemeral=ephemeral)
+    except discord.HTTPException as e:
+        # Only 10062 (Unknown interaction) is expected here: the token already expired,
+        # so there is no live interaction left to deliver the error reply to. That is
+        # planned fallout from an already-reported primary error, not a new fault —
+        # quietly skip it. Any other delivery failure is unexpected and must still
+        # escalate (the primary error, including a genuine timeout, is reported
+        # separately via log_error below).
+        if getattr(e, "code", None) == 10062:
+            logger.debug(f"Skipped error reply; interaction already gone: {e}")
+        else:
+            logger.error(f"Failed to send error message to user: {e}")
     except Exception as e:
         logger.error(f"Failed to send error message to user: {e}")
 


### PR DESCRIPTION
## Summary

Promotes the interaction-timeout fix to production. Both `/role` and `/repost` ran DB lookups and Discord API calls **before** sending their first response, so slow handling could exceed Discord's 3-second interaction window and 404 with `10062 (Unknown interaction)`. A single timed-out command fanned out into ~5 Sentry issues each (command log line + `error_handling` summary/detailed-context/traceback + a cascade when the handler then failed to notify the already-dead interaction).

This was the source of the 6 open `repost` issues (E/F/G/H/J/M) and the 4 `/role` issues already triaged.

## Changes

**Part A — fix the root cause (defer before slow work):**
- `cogs/roles.py` `/role`: `defer()` up front; final reply via `followup.send`.
- `cogs/gallery.py` `/repost`: `defer()` up front; menu surfaced via `edit_original_response` (so it stays the original response that `delete_original_response()` cleans up); early error replies via `followup.send`.

**Part B — stop the cascade without hiding real faults:**
- In both error-reply delivery paths, **only `10062`** (Unknown interaction) is treated as planned and logged at DEBUG — there is no live interaction left to deliver to.
- Any other delivery failure still escalates, and the **primary error (including a genuine timeout) is still reported via `log_error`** with full context, so slow-handling bugs continue to surface in Sentry for individual investigation.

## Verification
- `ruff format` / `ruff check`: clean
- 31 tests pass (`test_gallery_cog_repost`, `test_gallery_cog_admin`, `test_error_handling_property_based`, `test_cogs`)

## Post-deploy
Once the new release is live and the `repost` `10062`s stop firing, resolve issues E/F/G/H/J/M as fixed. Note: issue **E** (`on_submit`) / any "event loop already blocked before the handler ran" case can't be cured by `defer()` — those will keep escalating correctly until loop/startup latency is addressed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)