### PR TITLE
🧹 chore(observability): drop dead encryption config; process-scope disk I/O monitor

### DIFF
--- a/config/__init__.py
+++ b/config/__init__.py
@@ -155,13 +155,6 @@ class BotConfig(BaseModel):
         None, description="AO3 password", json_schema_extra={"sensitive": True}
     )
 
-    # Secret encryption key
-    secret_encryption_key: str | None = Field(
-        None,
-        description="Encryption key for secrets",
-        json_schema_extra={"sensitive": True},
-    )
-
     # Complex structures
     cookies: dict[str, str] = Field(
         default_factory=dict, description="Cookies for HTTP requests"
@@ -241,7 +234,6 @@ class BotConfig(BaseModel):
         "twitter_access_token",
         "twitter_access_token_secret",
         "ao3_password",
-        "secret_encryption_key",
     }
 
     _required_fields: set[str] = {
@@ -457,9 +449,6 @@ def load_from_env() -> BotConfig:
     ao3_username = get_env("AO3_USERNAME")
     ao3_password = get_env("AO3_PASSWORD")
 
-    # Secret encryption key
-    secret_encryption_key = get_env("SECRET_ENCRYPTION_KEY")
-
     # Staging environment settings
     staging_guild_id_str = get_env("STAGING_GUILD_ID")
     staging_guild_id = int(staging_guild_id_str) if staging_guild_id_str else None
@@ -540,7 +529,6 @@ def load_from_env() -> BotConfig:
             ao3_username=ao3_username,
             ao3_password=ao3_password,
             openai_api_key=openai_api_key,
-            secret_encryption_key=secret_encryption_key,
             cookies=cookies,
             headers=headers,
             channel_ids=channel_ids,
@@ -552,12 +540,6 @@ def load_from_env() -> BotConfig:
     except ValueError as e:
         # Add more context to validation errors
         raise ValueError(f"Configuration validation error: {e}") from e
-
-    # Log a warning if no encryption key is provided
-    if not secret_encryption_key:
-        logging.warning(
-            "No SECRET_ENCRYPTION_KEY provided. Sensitive data will not be encrypted."
-        )
 
     return config
 
@@ -616,7 +598,6 @@ twitter_access_token_secret = config.twitter_access_token_secret
 ao3_username = config.ao3_username
 ao3_password = config.ao3_password
 openai_api_key = config.openai_api_key
-secret_encryption_key = config.secret_encryption_key
 cookies = config.cookies
 headers = config.headers
 channel_ids = config.channel_ids

--- a/docs/developer/environment-variables.md
+++ b/docs/developer/environment-variables.md
@@ -222,22 +222,6 @@ WEBHOOK=https://discord.com/api/webhooks/...
 **Where to get:** Discord Server Settings → Integrations → Webhooks
 **Security:** 🔐 **Both are sensitive** (provide channel access)
 
-### Security Configuration
-
-```env
-SECRET_ENCRYPTION_KEY=your_32_character_encryption_key
-```
-
-**Description:** Encryption key for sensitive data storage
-**Security:** 🔐 **Highly Sensitive**
-**Generation:** Use a cryptographically secure random 32+ character string
-**Note:** If not set, sensitive data will not be encrypted (warning logged)
-
-**Generate a key:**
-```bash
-python -c "import secrets; print(secrets.token_urlsafe(32))"
-```
-
 ### Observability (Sentry)
 
 Optional. Enables runtime error reporting and the liveness heartbeat. Read
@@ -458,8 +442,6 @@ USER_AGENT=python:twi_bot_shard:v1.0dev by /u/yourname
 USERNAME=your_reddit_user
 PASSWORD=your_reddit_pass
 
-# Security
-SECRET_ENCRYPTION_KEY=your_generated_encryption_key
 ```
 
 ### Production Setup
@@ -496,9 +478,6 @@ USERNAME=prod_reddit_user
 PASSWORD=prod_reddit_pass
 AO3_USERNAME=prod_ao3_user
 AO3_PASSWORD=prod_ao3_pass
-
-# Security
-SECRET_ENCRYPTION_KEY=production_encryption_key_32chars_plus
 
 # Complex configurations
 COOKIES={"patreon_device_id":"prod_device_id"}

--- a/utils/resource_monitor.py
+++ b/utils/resource_monitor.py
@@ -71,7 +71,7 @@ class ResourceMonitor:
         self._max_history_size = 60  # Keep history for 60 intervals
 
         # Initialize I/O counters
-        self._last_disk_io = psutil.disk_io_counters()
+        self._last_disk_io = self._get_process_io_counters()
         self._last_net_io = psutil.net_io_counters()
         self._last_io_time = time.time()
 
@@ -102,6 +102,21 @@ class ResourceMonitor:
             "by_status": defaultdict(int),
             "by_remote_ip": defaultdict(int),
         }
+
+    def _get_process_io_counters(self) -> Any:
+        """Return this process's I/O counters, or None if unavailable.
+
+        Scoped to the bot process on purpose: ``psutil.disk_io_counters()`` is
+        host-wide (reads ``/proc/diskstats``), so on shared infra like Railway it
+        reports the whole node's disk activity — noisy neighbours included — which
+        the bot neither causes nor can control, and trips the threshold falsely.
+        ``Process.io_counters()`` is unsupported on some platforms (e.g. macOS),
+        so failures degrade gracefully to None.
+        """
+        try:
+            return self._process.io_counters()
+        except (psutil.AccessDenied, NotImplementedError, AttributeError):
+            return None
 
     async def start_monitoring(self) -> None:
         """Start the resource monitoring background task."""
@@ -251,11 +266,11 @@ class ResourceMonitor:
             "system_cpu_percent": psutil.cpu_percent(),
         }
 
-        # Disk I/O stats
-        current_disk_io = psutil.disk_io_counters()
+        # Disk I/O stats (scoped to this process — see _get_process_io_counters)
+        current_disk_io = self._get_process_io_counters()
         time_diff = current_time - self._last_io_time
 
-        if self._last_disk_io and time_diff > 0:
+        if self._last_disk_io and current_disk_io and time_diff > 0:
             read_bytes_per_sec = (
                 current_disk_io.read_bytes - self._last_disk_io.read_bytes
             ) / time_diff
@@ -269,8 +284,6 @@ class ResourceMonitor:
                     "disk_write_bytes_per_sec": write_bytes_per_sec,
                     "disk_read_count": current_disk_io.read_count,
                     "disk_write_count": current_disk_io.write_count,
-                    "disk_read_time": current_disk_io.read_time,
-                    "disk_write_time": current_disk_io.write_time,
                 }
             )
 


### PR DESCRIPTION
## Summary

Cleanup of two misleading production-log warnings surfaced while reviewing Railway logs. Neither is a live incident — both are observability hygiene.

### #1 — Remove dead `SECRET_ENCRYPTION_KEY` config
`SECRET_ENCRYPTION_KEY` was read into config and logged a warning when absent (`Sensitive data will not be encrypted`), but **nothing in the codebase ever used it** — there is no encryption implemented anywhere (no `Fernet`/`cryptography`/`SecretManager`, no `.encrypt()`/`.decrypt()` calls). The warning therefore overstated the situation in production.

Removed: the unused Pydantic field, its `_sensitive_fields` entry, the env read, the constructor arg, the module-level export, the misleading warning, and the docs that documented it. If encryption is wanted later, that's a feature PR, not dangling config.

### #2 — Process-scope the disk-I/O monitor
The resource monitor used `psutil.disk_io_counters()`, which is **host-wide** (`/proc/diskstats`). In a container on shared infra (Railway) that reports the whole node's disk throughput, so a static 80 MB/s threshold trips on noisy-neighbour activity the bot neither causes nor can control — pure log noise every poll interval.

Switched to `Process.io_counters()` via a guarded helper (`_get_process_io_counters`) that degrades to `None` on platforms without it (e.g. macOS). Dropped the `read_time`/`write_time` stat fields — they don't exist on process counters and were never read anywhere.

## Verification
- `ruff format` / `ruff check`: clean (incl. no now-unused `logging` import)
- `config` imports cleanly; `secret_encryption_key` attr gone from module and config object
- `Process.io_counters()` confirmed working (process-scoped fields present)
- Tests pass: `test_resource_optimization`, `test_cogs`, `test_dependencies`

🤖 Generated with [Claude Code](https://claude.com/claude-code)