### PR TITLE
📊 observability: surface DB pool contention + DB observability runbook

### DIFF
--- a/docs/operations/observability.md
+++ b/docs/operations/observability.md
@@ -79,6 +79,96 @@ test scripts that force `environment='staging'`/`'production'` will trip the rea
 Discord alerts. Tag throwaway test events with a distinct environment (e.g.
 `local-test`).
 
+## Database observability
+
+The database is the easiest layer to be blind to, because the app-side timer in
+`utils/db.py` measures **connection-acquire wait + query execution together**.
+A "slow query" on a trivial statement is therefore usually *pool contention*
+(waiting for a free connection), not a slow query. Visibility comes from three
+layers — app, pool, and the Postgres server.
+
+### What the bot already records (code, always on)
+
+- **Slow-query log** (`utils/db.py`, threshold 0.5s): every query method warns
+  when total time exceeds the threshold. The warning carries a
+  `[pool: N/M idle]` suffix — **0 idle means the time was spent waiting on a
+  saturated pool** (contention), not in the query. A healthy idle count means
+  the query (or the server) was genuinely slow.
+- **Pool utilisation** (`utils/resource_monitor.py`): the resource monitor is
+  handed the asyncpg pool and records `db_pool_size` / `db_pool_idle` /
+  `db_pool_in_use` / `db_pool_max` each cycle, and emits a
+  `DB connection pool saturated` warning when idle hits 0. The pool is min 5 /
+  max 20 (`main.py`).
+
+### Layer 1 — Sentry query tracing (lowest effort, highest value)
+
+The asyncpg integration already emits `op:db origin:auto.db.asyncpg` spans
+(visible in the `trace` block of any captured event) — they are just dropped
+because sampling is off. To turn on the **Queries** insights dashboard
+(slowest/most-frequent queries, per-command timing, N+1 detection):
+
+1. On Railway, set `SENTRY_TRACES_SAMPLE_RATE` to a small value (e.g. `0.1`) on
+   the `staging` / `production` service. No deploy needed — restart the service.
+2. Open Sentry → **Insights → Queries** for the project. Start low (0.05–0.1):
+   tracing consumes quota and adds slight overhead. Query *parameters* are not
+   captured (`send_default_pii=False` + parameterised SQL).
+
+### Layer 2 — `pg_stat_statements` (authoritative server-side truth)
+
+The canonical Postgres tool: aggregates every normalised query with call count,
+total/mean/max time, rows, and cache-hit ratio. One-time setup on the Railway
+Postgres service:
+
+1. Add `pg_stat_statements` to `shared_preload_libraries` (Railway Postgres
+   service config) and restart the DB.
+2. Once: `CREATE EXTENSION IF NOT EXISTS pg_stat_statements;`
+3. Read the top offenders any time:
+   ```sql
+   SELECT calls, total_exec_time, mean_exec_time, max_exec_time, rows, query
+   FROM pg_stat_statements
+   ORDER BY total_exec_time DESC
+   LIMIT 20;
+   ```
+   (`total_exec_time` = biggest cumulative cost; `mean_exec_time` = slowest per
+   call.) Reset the counters with `SELECT pg_stat_statements_reset();`.
+
+### Layer 3 — server-side slow log + plans (why a query is slow)
+
+On the Railway Postgres service, set:
+
+- `log_min_duration_statement = 500` — logs any statement over 500ms
+  (authoritative execution time, no pool-wait noise).
+- `auto_explain` (add to `shared_preload_libraries`) with
+  `auto_explain.log_min_duration = '500ms'` and `auto_explain.log_analyze = on`
+  — captures the actual `EXPLAIN ANALYZE` plan for slow statements, surfacing
+  missing indexes / sequential scans.
+
+For ad-hoc investigation of a specific query, run
+`EXPLAIN (ANALYZE, BUFFERS) <query>;` against the DB.
+
+### Live "what's happening right now"
+
+```sql
+-- currently-running queries and what they're waiting on
+SELECT pid, now() - query_start AS duration, wait_event_type, wait_event, query
+FROM pg_stat_activity
+WHERE state = 'active' AND query NOT ILIKE '%pg_stat_activity%'
+ORDER BY duration DESC;
+
+-- blocked / blocking locks
+SELECT * FROM pg_locks WHERE NOT granted;
+```
+
+### Triage flow for a slow-query warning
+
+1. Check the `[pool: N/M idle]` suffix. `0` idle → contention; consider raising
+   pool `max_size` (`main.py`) or reducing concurrent DB work. Non-zero idle →
+   the query/server was genuinely slow, continue below.
+2. Find the query in **Sentry → Queries** or `pg_stat_statements` to see how
+   often it runs and its true execution time.
+3. If genuinely slow, `EXPLAIN (ANALYZE, BUFFERS)` it (or read the `auto_explain`
+   plan) to find the missing index / scan.
+
 ## Related Documentation
 
 - [Error Handling](../developer/error-handling.md) — exception hierarchy and escalation paths

--- a/main.py
+++ b/main.py
@@ -173,6 +173,7 @@ class Cognita(commands.Bot):
             memory_leak_threshold=52428800,  # 50MB threshold to reduce false positives
             enable_memory_leak_detection=True,
             logger=self.logger.getChild("resource_monitor"),
+            pool=self.db.pool,  # surface DB pool saturation / utilization
         )
 
         # Initialize service container

--- a/utils/db.py
+++ b/utils/db.py
@@ -110,6 +110,22 @@ class Database:
             logger=self.logger,
         )
 
+    def _pool_usage_suffix(self) -> str:
+        """Return a ' [pool: N/M idle]' suffix for slow-query logs.
+
+        The slow-query timer wraps connection acquisition + execution together, so
+        a slow query logged with 0 idle connections almost always means the time
+        was spent waiting to acquire a connection (pool contention) rather than in
+        the query itself. Surfacing idle/max here is the single most useful
+        disambiguation when triaging a slow-query warning.
+        """
+        try:
+            return (
+                f" [pool: {self.pool.get_idle_size()}/{self.pool.get_max_size()} idle]"
+            )
+        except Exception:
+            return ""
+
     async def check_connection_health(self) -> bool:
         """Check if the database connection is healthy.
 
@@ -224,7 +240,10 @@ class Database:
                 if monitor:
                     duration = time.time() - cast(float, start_time)
                     if duration > self.slow_query_threshold:
-                        self.logger.warning(f"Slow query ({duration:.2f}s): {query}")
+                        self.logger.warning(
+                            f"Slow query ({duration:.2f}s): {query}"
+                            f"{self._pool_usage_suffix()}"
+                        )
 
                 return cast("str | None", result)
             except (asyncpg.PostgresConnectionError, asyncpg.PostgresError) as e:
@@ -323,7 +342,10 @@ class Database:
                 if monitor:
                     duration = time.time() - cast(float, start_time)
                     if duration > self.slow_query_threshold:
-                        self.logger.warning(f"Slow query ({duration:.2f}s): {query}")
+                        self.logger.warning(
+                            f"Slow query ({duration:.2f}s): {query}"
+                            f"{self._pool_usage_suffix()}"
+                        )
 
                 return cast("Sequence[Record]", result)
             except (asyncpg.PostgresConnectionError, asyncpg.PostgresError) as e:
@@ -384,7 +406,10 @@ class Database:
                 if monitor:
                     duration = time.time() - cast(float, start_time)
                     if duration > self.slow_query_threshold:
-                        self.logger.warning(f"Slow query ({duration:.2f}s): {query}")
+                        self.logger.warning(
+                            f"Slow query ({duration:.2f}s): {query}"
+                            f"{self._pool_usage_suffix()}"
+                        )
 
                 return result
             except (asyncpg.PostgresConnectionError, asyncpg.PostgresError) as e:
@@ -449,7 +474,10 @@ class Database:
                 if monitor:
                     duration = time.time() - cast(float, start_time)
                     if duration > self.slow_query_threshold:
-                        self.logger.warning(f"Slow query ({duration:.2f}s): {query}")
+                        self.logger.warning(
+                            f"Slow query ({duration:.2f}s): {query}"
+                            f"{self._pool_usage_suffix()}"
+                        )
 
                 return result
             except (asyncpg.PostgresConnectionError, asyncpg.PostgresError) as e:
@@ -579,6 +607,7 @@ class Database:
                     if duration > self.slow_query_threshold:
                         self.logger.warning(
                             f"Slow batch query ({duration:.2f}s): {query} with {len(args_list)} records"
+                            f"{self._pool_usage_suffix()}"
                         )
 
                 return
@@ -645,6 +674,7 @@ class Database:
                     if duration > self.slow_query_threshold:
                         self.logger.warning(
                             f"Slow COPY operation ({duration:.2f}s): COPY {len(records)} records to {table_name}{column_str}"
+                            f"{self._pool_usage_suffix()}"
                         )
 
                 return
@@ -729,6 +759,7 @@ class Database:
                         if duration > self.slow_query_threshold:
                             self.logger.warning(
                                 f"Slow script execution ({duration:.2f}s): {script_path}"
+                                f"{self._pool_usage_suffix()}"
                             )
 
                     self.logger.info(f"Successfully executed script: {script_path}")
@@ -809,7 +840,10 @@ class Database:
                 if monitor:
                     duration = time.time() - cast(float, start_time)
                     if duration > self.slow_query_threshold:
-                        self.logger.warning(f"Slow query ({duration:.2f}s): {query}")
+                        self.logger.warning(
+                            f"Slow query ({duration:.2f}s): {query}"
+                            f"{self._pool_usage_suffix()}"
+                        )
 
                 return cast("Sequence[Record]", result)
             except TimeoutError:
@@ -874,7 +908,10 @@ class Database:
                 if monitor:
                     duration = time.time() - cast(float, start_time)
                     if duration > self.slow_query_threshold:
-                        self.logger.warning(f"Slow query ({duration:.2f}s): {query}")
+                        self.logger.warning(
+                            f"Slow query ({duration:.2f}s): {query}"
+                            f"{self._pool_usage_suffix()}"
+                        )
 
                 return result
             except TimeoutError:

--- a/utils/resource_monitor.py
+++ b/utils/resource_monitor.py
@@ -40,6 +40,7 @@ class ResourceMonitor:
         enable_memory_leak_detection: bool = True,
         memory_leak_threshold: int = 52428800,  # 50 MB (increased from 10MB)
         logger: logging.Logger | None = None,
+        pool: Any = None,
     ) -> None:
         """Initialize the resource monitor.
 
@@ -53,6 +54,8 @@ class ResourceMonitor:
             enable_memory_leak_detection: Whether to enable memory leak detection.
             memory_leak_threshold: Threshold in bytes for memory leak detection.
             logger: Logger instance to use for logging.
+            pool: Optional asyncpg connection pool to monitor for utilization /
+                saturation. Accepted as Any to avoid importing asyncpg here.
         """
         self.check_interval = check_interval
         self.memory_threshold = memory_threshold
@@ -63,6 +66,7 @@ class ResourceMonitor:
         self.enable_memory_leak_detection = enable_memory_leak_detection
         self.memory_leak_threshold = memory_leak_threshold
         self.logger = logger or logging.getLogger("resource_monitor")
+        self.pool = pool
 
         # Initialize monitoring state
         self._monitoring_task: asyncio.Task[None] | None = None
@@ -197,6 +201,16 @@ class ResourceMonitor:
                         f"High connection count detected: {stats['connection_count']} connections"
                     )
 
+                # Warn when the DB connection pool is saturated — queries then
+                # block waiting to acquire a connection, which surfaces as "slow"
+                # trivial queries even though the SQL itself is fast.
+                if stats.get("db_pool_idle") == 0 and stats.get("db_pool_max", 0) > 0:
+                    self.logger.warning(
+                        f"DB connection pool saturated: "
+                        f"{stats['db_pool_in_use']}/{stats['db_pool_max']} in use, "
+                        f"0 idle — queries may be waiting to acquire a connection"
+                    )
+
                 # Check for garbage collection issues
                 if self.enable_gc_monitoring and "gc_objects" in stats:
                     if stats["gc_objects"] > 1000000:  # Arbitrary threshold
@@ -315,6 +329,25 @@ class ResourceMonitor:
 
         self._last_net_io = current_net_io
         self._last_io_time = current_time
+
+        # Database connection pool stats (asyncpg). Surfacing idle/in-use makes
+        # pool saturation — the usual cause of "slow" trivial queries waiting to
+        # acquire a connection — visible over time.
+        if self.pool is not None:
+            try:
+                pool_max = self.pool.get_max_size()
+                pool_size = self.pool.get_size()
+                pool_idle = self.pool.get_idle_size()
+                stats.update(
+                    {
+                        "db_pool_max": pool_max,
+                        "db_pool_size": pool_size,
+                        "db_pool_idle": pool_idle,
+                        "db_pool_in_use": pool_size - pool_idle,
+                    }
+                )
+            except Exception as e:
+                self.logger.debug(f"Could not read DB pool stats: {e}")
 
         # Garbage collection stats
         if self.enable_gc_monitoring:


### PR DESCRIPTION
## Summary

Makes the database layer measurable instead of a black box. Motivated by the isolated `Slow query (3.67s): INSERT INTO users ...` — a trivial upsert can't take 3.67s to *execute*; the timer wraps connection-acquire wait + execution, so it was almost certainly pool contention, which we previously couldn't tell apart.

## Code

- **`utils/db.py`** — slow-query warnings now append `[pool: N/M idle]`. **0 idle ⇒ contention** (waiting to acquire a connection); healthy idle ⇒ the query/server was genuinely slow. Pure logging change — execution and retry paths untouched.
- **`utils/resource_monitor.py`** — accepts the asyncpg pool, records `db_pool_size/idle/in_use/max` each cycle, and warns `DB connection pool saturated` when idle hits 0. `main.py` wires `pool=self.db.pool`.

I deliberately chose pool-state-in-the-warning over a full per-method acquire/exec rewrite — same contention-vs-slow-query signal, far less risk to the most critical file.

## Docs (runbook)

`docs/operations/observability.md` gains a **Database observability** section covering the three layers and exactly how to turn each on:
- **Sentry query tracing** — set `SENTRY_TRACES_SAMPLE_RATE=0.1` (the `auto.db.asyncpg` spans already exist; just unsampled). No deploy, restart only.
- **`pg_stat_statements`** — setup + the top-offenders query.
- **`log_min_duration_statement` + `auto_explain`** — server-side slow log and plans.
- Live `pg_stat_activity` / `pg_locks` queries, and a slow-query triage flow.

## Verification
- `ruff` clean; 14 db/resource/transaction tests pass; smoke-tested pool-stats collection, the saturation condition, the no-pool path, and the `[pool: …]` suffix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)