### PR TITLE
🐛 fix: correct false DB pool-saturated warning + clearer slow-query pool suffix

### DIFF
--- a/docs/operations/observability.md
+++ b/docs/operations/observability.md
@@ -91,14 +91,27 @@ layers — app, pool, and the Postgres server.
 
 - **Slow-query log** (`utils/db.py`, threshold 0.5s): every query method warns
   when total time exceeds the threshold. The warning carries a
-  `[pool: N/M idle]` suffix — **0 idle means the time was spent waiting on a
-  saturated pool** (contention), not in the query. A healthy idle count means
-  the query (or the server) was genuinely slow.
+  `[pool: X in use, Y idle, Z open, M max]` suffix so you can tell *why* it was
+  slow (the timer wraps acquire + execution together):
+  - `in use == max` → **saturation**, the query waited for a connection;
+  - `open == 0` → **cold connect**, the pool had drained to empty and had to
+    open a fresh (TLS) connection — the usual cause of a one-off multi-second
+    "slow" trivial query (see the note on `max_inactive_connection_lifetime`
+    below);
+  - otherwise → the **query/server itself** was genuinely slow.
 - **Pool utilisation** (`utils/resource_monitor.py`): the resource monitor is
   handed the asyncpg pool and records `db_pool_size` / `db_pool_idle` /
   `db_pool_in_use` / `db_pool_max` each cycle, and emits a
-  `DB connection pool saturated` warning when idle hits 0. The pool is min 5 /
-  max 20 (`main.py`).
+  `DB connection pool saturated` warning only when **in-use reaches max** (not
+  merely when idle is 0 — a quiescent pool also reports 0 idle).
+
+> **Why the pool often shows 0 open/idle:** the pool is created with
+> `max_inactive_connection_lifetime=180.0` (`main.py`), so after ~3 min without
+> DB activity asyncpg closes its idle connections and the pool shrinks toward 0.
+> The next query then pays a cold-connection (TLS handshake) cost, which the
+> app-side timer attributes to that query. If cold-connect latency becomes a
+> problem, raise/disable that lifetime or add a periodic keepalive query so a
+> warm connection is always available. Pool is min 5 / max 20.
 
 ### Layer 1 — Sentry query tracing (lowest effort, highest value)
 
@@ -161,9 +174,11 @@ SELECT * FROM pg_locks WHERE NOT granted;
 
 ### Triage flow for a slow-query warning
 
-1. Check the `[pool: N/M idle]` suffix. `0` idle → contention; consider raising
-   pool `max_size` (`main.py`) or reducing concurrent DB work. Non-zero idle →
-   the query/server was genuinely slow, continue below.
+1. Read the `[pool: …]` suffix. `in use == max` → contention (raise pool
+   `max_size` in `main.py` or reduce concurrent DB work). `open == 0` → cold
+   connect after the pool drained (see the `max_inactive_connection_lifetime`
+   note above) — not a query problem. Otherwise the query/server was genuinely
+   slow; continue below.
 2. Find the query in **Sentry → Queries** or `pg_stat_statements` to see how
    often it runs and its true execution time.
 3. If genuinely slow, `EXPLAIN (ANALYZE, BUFFERS)` it (or read the `auto_explain`

--- a/utils/db.py
+++ b/utils/db.py
@@ -111,17 +111,24 @@ class Database:
         )
 
     def _pool_usage_suffix(self) -> str:
-        """Return a ' [pool: N/M idle]' suffix for slow-query logs.
+        """Return a ' [pool: …]' suffix for slow-query logs.
 
         The slow-query timer wraps connection acquisition + execution together, so
-        a slow query logged with 0 idle connections almost always means the time
-        was spent waiting to acquire a connection (pool contention) rather than in
-        the query itself. Surfacing idle/max here is the single most useful
-        disambiguation when triaging a slow-query warning.
+        the slowness can be (a) genuine query/server time, (b) waiting on a fully
+        saturated pool, or (c) the cold-connection cost when the pool had shrunk to
+        0 (asyncpg closes idle connections per max_inactive_connection_lifetime).
+        Reporting in-use / idle / open / max lets triage tell these apart:
+
+        - ``in_use == max``       → saturation (next acquirer waits)
+        - ``open == 0``           → cold connect (pool had drained to empty)
+        - otherwise               → the query/server itself was slow
         """
         try:
+            size = self.pool.get_size()
+            idle = self.pool.get_idle_size()
             return (
-                f" [pool: {self.pool.get_idle_size()}/{self.pool.get_max_size()} idle]"
+                f" [pool: {size - idle} in use, {idle} idle, "
+                f"{size} open, {self.pool.get_max_size()} max]"
             )
         except Exception:
             return ""

--- a/utils/resource_monitor.py
+++ b/utils/resource_monitor.py
@@ -201,14 +201,17 @@ class ResourceMonitor:
                         f"High connection count detected: {stats['connection_count']} connections"
                     )
 
-                # Warn when the DB connection pool is saturated — queries then
-                # block waiting to acquire a connection, which surfaces as "slow"
-                # trivial queries even though the SQL itself is fast.
-                if stats.get("db_pool_idle") == 0 and stats.get("db_pool_max", 0) > 0:
+                # Warn only on genuine saturation: every connection the pool can
+                # open is checked out, so the next acquirer must wait. Requiring
+                # in_use >= max avoids a false positive on a quiescent pool, which
+                # also reports 0 idle simply because asyncpg has closed its idle
+                # connections (max_inactive_connection_lifetime) and shrunk to 0.
+                pool_max = stats.get("db_pool_max", 0)
+                if pool_max > 0 and stats.get("db_pool_in_use", 0) >= pool_max:
                     self.logger.warning(
                         f"DB connection pool saturated: "
-                        f"{stats['db_pool_in_use']}/{stats['db_pool_max']} in use, "
-                        f"0 idle — queries may be waiting to acquire a connection"
+                        f"{stats['db_pool_in_use']}/{pool_max} connections in use, "
+                        f"0 idle — further queries will wait to acquire a connection"
                     )
 
                 # Check for garbage collection issues


### PR DESCRIPTION
## Summary

Follow-up fix to the DB observability that just shipped (PR #51). The new `DB connection pool saturated` warning is firing in **production** as `0/20 in use, 0 idle` — a **false positive**.

**Root cause:** the pool is configured with `max_inactive_connection_lifetime=180.0` (`main.py`), so after ~3 min idle asyncpg closes its connections and the pool shrinks to 0. `get_idle_size()` then returns 0 for a *quiescent* pool, which the old `idle == 0` condition couldn't distinguish from a *saturated* one.

This also reframes the original 3.67s `users` upsert: almost certainly **cold-connection cost** (TLS handshake to open a fresh connection after the pool drained), not contention.

## Changes
- **`resource_monitor.py`** — warn only on genuine saturation (`in_use >= max`); a drained quiescent pool no longer trips it.
- **`db.py`** — slow-query suffix now reports `X in use, Y idle, Z open, M max`, so triage distinguishes: saturation (`in_use==max`), cold connect (`open==0`), or a genuinely slow query/server.
- **`observability.md`** — documents the three-way interpretation and the `max_inactive_connection_lifetime` cold-connect behaviour + mitigations (raise/disable the lifetime, or a keepalive query).

## Verification
- Smoke-tested: quiescent pool (size 0) no longer warns; 20/20 does; suffix unambiguous.
- 14 db/resource/cog tests pass; ruff clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)