### PR TITLE
🗃️ chore(db): validate FKs + drop 11 redundant indexes (repo sync)

### DIFF
--- a/database/init.sql
+++ b/database/init.sql
@@ -179,7 +179,7 @@ CREATE UNIQUE INDEX IF NOT EXISTS messages_id_uindex ON messages (message_id);
 CREATE INDEX IF NOT EXISTS messages_channel_id_index ON messages (channel_id DESC);
 CREATE INDEX IF NOT EXISTS messages_message_id_channel_id_index ON messages (message_id DESC, channel_id ASC);
 CREATE INDEX IF NOT EXISTS messages_created_at_index ON messages (created_at DESC);
-CREATE INDEX IF NOT EXISTS messages_user_id_index ON messages (user_id);
+-- messages_user_id_index omitted: covered by idx_messages_user_created (user_id, created_at).
 
 -- Attachments table (depends on messages)
 CREATE TABLE IF NOT EXISTS attachments
@@ -356,7 +356,7 @@ CREATE TABLE IF NOT EXISTS creator_links
 );
 
 CREATE UNIQUE INDEX IF NOT EXISTS creator_links_serial_id_uindex ON creator_links (serial_id DESC);
-CREATE INDEX IF NOT EXISTS creator_links_user_id_index ON creator_links (user_id);
+-- creator_links_user_id_index omitted: covered by creator_links_pk (user_id, title).
 
 -- Emotes table (depends on servers)
 CREATE TABLE IF NOT EXISTS emotes

--- a/database/optimizations/base.sql
+++ b/database/optimizations/base.sql
@@ -80,15 +80,16 @@ CREATE INDEX IF NOT EXISTS idx_messages_user_created_at ON messages(user_id, cre
 CREATE INDEX IF NOT EXISTS idx_reactions_message_emoji ON reactions(message_id, emoji_id);
 CREATE INDEX IF NOT EXISTS idx_reactions_message_unicode ON reactions(message_id, unicode_emoji);
 
--- For role membership queries
-CREATE INDEX IF NOT EXISTS idx_role_membership_role ON role_membership(role_id);
+-- For role membership queries: role_id alone is covered by
+-- role_membership_role_id_user_id_index (role_id, user_id), so a standalone
+-- role_id index is redundant and intentionally omitted.
 
 -- 4. Add Indexes for Foreign Keys
 -- Add index for message_id in attachments
 CREATE INDEX IF NOT EXISTS idx_attachments_message_id ON attachments(message_id);
 
--- Add index for user_id in creator_links
-CREATE INDEX IF NOT EXISTS idx_creator_links_user_id ON creator_links(user_id);
+-- user_id in creator_links is covered by creator_links_pk (user_id, title),
+-- so a standalone user_id index is redundant and intentionally omitted.
 
 -- 5. Add Partial Indexes for Specific Queries
 -- Index for non-deleted messages only
@@ -165,9 +166,8 @@ $$ LANGUAGE plpgsql;
 
 -- Indexes for frequently queried columns in messages table
 CREATE INDEX IF NOT EXISTS idx_messages_created_at ON messages(created_at);
-CREATE INDEX IF NOT EXISTS idx_messages_server_id ON messages(server_id);
-CREATE INDEX IF NOT EXISTS idx_messages_channel_id ON messages(channel_id);
-CREATE INDEX IF NOT EXISTS idx_messages_user_id ON messages(user_id);
+-- server_id / channel_id / user_id single-column indexes intentionally omitted:
+-- each is covered by the matching (col, created_at) composite created just below.
 CREATE INDEX IF NOT EXISTS idx_messages_is_bot ON messages(is_bot);
 
 -- Composite indexes for common query patterns
@@ -181,7 +181,7 @@ CREATE INDEX IF NOT EXISTS idx_join_leave_server_id ON join_leave(server_id);
 CREATE INDEX IF NOT EXISTS idx_join_leave_is_join ON join_leave(is_join);
 
 -- Indexes for reactions table
-CREATE INDEX IF NOT EXISTS idx_reactions_message_id ON reactions(message_id);
+-- message_id alone is covered by idx_reactions_message_emoji (message_id, emoji_id).
 CREATE INDEX IF NOT EXISTS idx_reactions_user_id ON reactions(user_id);
 CREATE INDEX IF NOT EXISTS idx_reactions_date ON reactions(date);
 

--- a/database/schema/migrations/20260608_validate_fks_drop_redundant_indexes.sql
+++ b/database/schema/migrations/20260608_validate_fks_drop_redundant_indexes.sql
@@ -1,0 +1,73 @@
+-- =============================================================
+-- Migration: Validate FK constraints + drop redundant indexes
+-- Generated: 2026-06-08
+-- Database: Cognita Discord Bot (PostgreSQL)
+-- Status: APPLIED to production 2026-06-08 (via psql).
+-- Source: pgHero "Invalid Constraints" + "Duplicate Indexes" findings.
+-- IMPORTANT: Run during a low-traffic period.
+-- IMPORTANT: Do NOT run with --single-transaction or inside a
+--            BEGIN/COMMIT block. CONCURRENTLY operations require
+--            autocommit mode and will fail inside a transaction.
+-- =============================================================
+
+\set ON_ERROR_STOP 1
+
+-- =============================================================
+-- SECTION 1: Clean orphaned child rows, then VALIDATE the FKs
+-- =============================================================
+-- attachments_messages_fk and mentions_messages_fk were added
+-- NOT VALID, so existing rows were never checked. Production had
+-- 15 attachments and 3 mentions referencing messages that no
+-- longer exist (dead, unreachable rows). VALIDATE fails until
+-- they're removed. The FKs have no ON DELETE CASCADE, but the bot
+-- soft-deletes messages (deleted=true), so validating does not
+-- affect normal deletion.
+
+DELETE FROM attachments a
+ WHERE a.message_id IS NOT NULL
+   AND NOT EXISTS (SELECT 1 FROM messages m WHERE m.message_id = a.message_id);
+
+DELETE FROM mentions x
+ WHERE x.message_id IS NOT NULL
+   AND NOT EXISTS (SELECT 1 FROM messages m WHERE m.message_id = x.message_id);
+
+ALTER TABLE attachments VALIDATE CONSTRAINT attachments_messages_fk;
+ALTER TABLE mentions VALIDATE CONSTRAINT mentions_messages_fk;
+
+-- =============================================================
+-- SECTION 2: Drop redundant indexes (each covered by a composite)
+-- =============================================================
+-- Every index below is fully covered by an existing composite /
+-- primary-key / unique index whose leading column matches, so the
+-- single-column index only adds write + space overhead. Freed
+-- ~550 MB (most of it on messages). The corresponding CREATE INDEX
+-- statements were removed from database/optimizations/base.sql,
+-- database/init.sql, database/schema/tables.sql, and
+-- database/utilities/gallery-migration.sql so they are not
+-- recreated. (The 20260405 cleanup migration also listed two of
+-- these but was never applied; this migration supersedes it.)
+
+-- covered by creator_links_pk (user_id, title)
+DROP INDEX CONCURRENTLY IF EXISTS idx_creator_links_user_id;
+DROP INDEX CONCURRENTLY IF EXISTS creator_links_user_id_index;
+
+-- covered by gallery_migration_message_id_key (message_id) unique
+DROP INDEX CONCURRENTLY IF EXISTS idx_gallery_migration_message_id;
+
+-- covered by gallery_posts_message_id_key (message_id) unique
+DROP INDEX CONCURRENTLY IF EXISTS idx_gallery_posts_message_id;
+
+-- covered by the messages (col, created_at) composites
+DROP INDEX CONCURRENTLY IF EXISTS idx_messages_channel_id;     -- idx_messages_channel_created
+DROP INDEX CONCURRENTLY IF EXISTS idx_messages_server_id;      -- idx_messages_server_created
+DROP INDEX CONCURRENTLY IF EXISTS idx_messages_user_id;        -- idx_messages_user_created
+DROP INDEX CONCURRENTLY IF EXISTS messages_user_id_index;      -- idx_messages_user_created
+
+-- covered by idx_reactions_message_emoji (message_id, emoji_id)
+DROP INDEX CONCURRENTLY IF EXISTS idx_reactions_message_id;
+
+-- covered by idx_reports_unique_user_message (message_id, user_id)
+DROP INDEX CONCURRENTLY IF EXISTS idx_reports_message_id;
+
+-- covered by role_membership_role_id_user_id_index (role_id, user_id)
+DROP INDEX CONCURRENTLY IF EXISTS idx_role_membership_role;

--- a/database/schema/tables.sql
+++ b/database/schema/tables.sql
@@ -308,8 +308,7 @@ create index messages_message_id_channel_id_index
 create index messages_created_at_index
     on messages (created_at desc);
 
-create index messages_user_id_index
-    on messages (user_id);
+-- messages_user_id_index omitted: covered by idx_messages_user_created (user_id, created_at).
 
 create unique index servers_serial_id_uindex
     on servers (serial_id);
@@ -554,8 +553,7 @@ create table creator_links
 create unique index creator_links_serial_id_uindex
     on creator_links (serial_id desc);
 
-create index creator_links_user_id_index
-    on creator_links (user_id);
+-- creator_links_user_id_index omitted: covered by creator_links_pk (user_id, title).
 
 create table button_action_history
 (

--- a/database/utilities/gallery-migration.sql
+++ b/database/utilities/gallery-migration.sql
@@ -47,7 +47,7 @@ CREATE TABLE gallery_migration (
 );
 
 -- Indexes for performance
-CREATE INDEX idx_gallery_migration_message_id ON gallery_migration (message_id);
+-- message_id omitted: covered by the gallery_migration_message_id_key unique constraint.
 CREATE INDEX idx_gallery_migration_channel_id ON gallery_migration (channel_id);
 CREATE INDEX idx_gallery_migration_migrated ON gallery_migration (migrated);
 CREATE INDEX idx_gallery_migration_needs_review ON gallery_migration (needs_manual_review, reviewed);

--- a/scripts/database/apply_migrations.py
+++ b/scripts/database/apply_migrations.py
@@ -53,6 +53,10 @@ MIGRATIONS_DIR = (
 MANUAL_MIGRATIONS: frozenset[str] = frozenset(
     {
         "20260405_database_design_cleanup.sql",
+        # Applied by hand to production 2026-06-08 (psql). Uses DROP INDEX
+        # CONCURRENTLY + a psql \set meta-command, so it is not transaction-safe
+        # and must not be auto-executed; recorded-as-applied only.
+        "20260608_validate_fks_drop_redundant_indexes.sql",
     }
 )
 


### PR DESCRIPTION
Repo sync for a DB cleanup **already applied to production** (2026-06-08 via psql), from pgHero's *Invalid Constraints* + *Duplicate Indexes* findings.

## Applied to production
- **Validated 2 FK constraints** — `attachments_messages_fk`, `mentions_messages_fk` were `NOT VALID` (existing rows never checked). Deleted **15 orphan `attachments` + 3 orphan `mentions`** (dead rows pointing at missing messages), then `VALIDATE`d both → `convalidated=true`. FKs have no `ON DELETE CASCADE`, but the bot soft-deletes messages, so this doesn't affect deletion.
- **Dropped 11 redundant indexes** (`CONCURRENTLY`, non-locking), each fully covered by an existing composite/PK/unique index — freed **~550 MB**, most on the hot `messages` table, and reduced its write amplification. Verified: 0 of the 11 remain, 6 covering composites intact, 0 invalid indexes left behind.

## Repo changes (this PR)
- Removed the redundant `CREATE INDEX` statements from `optimizations/base.sql`, `init.sql`, `schema/tables.sql`, `utilities/gallery-migration.sql` (each with a comment naming the covering index) so `optimize.py` / fresh deploys don't recreate them. Composites kept.
- New migration `20260608_validate_fks_drop_redundant_indexes.sql` documenting exactly what was applied (supersedes the never-applied `20260405` entries for the two messages/creator_links indexes).
- No model change needed — schema source is the SQL files, not SQLAlchemy `create_all` (no `ix_`-prefixed indexes exist in prod).

## Follow-up (not in this PR)
`messages`/`reactions` are over-indexed beyond pgHero's exact-duplicate detection — `base.sql` creates both `_created` (ASC) and `_created_at` (DESC) variants of the same composites, plus several large 0-scan indexes. Worth a separate, data-driven pass once scan-stats accumulate a meaningful window.

🤖 Generated with [Claude Code](https://claude.com/claude-code)