### PR TITLE
🐛 fix(sentry): total_votes UnboundLocalError + role color int→str cast

### DIFF
--- a/cogs/patreon_poll.py
+++ b/cogs/patreon_poll.py
@@ -638,6 +638,7 @@ async def p_poll(polls, interaction, bot) -> None:
                 )
 
             # Add poll options as embed fields
+            total_votes = 0
             if not options:
                 embed.add_field(
                     name="⚠️ No Options Available",

--- a/cogs/stats_listeners.py
+++ b/cogs/stats_listeners.py
@@ -1150,7 +1150,7 @@ class StatsListenersMixin(StatsMixinBase):
                 role.id,
                 role.name,
                 role.guild.id,
-                role.color.value,
+                str(role.color.value),
                 role.position,
                 role.permissions.value,
                 role.created_at.replace(tzinfo=None),
@@ -1513,7 +1513,7 @@ class StatsListenersMixin(StatsMixinBase):
             await self.bot.db.execute(
                 "UPDATE roles SET name = $1, color = $2, position = $3, permissions = $4 WHERE id = $5",
                 after.name,
-                after.color.value,
+                str(after.color.value),
                 after.position,
                 after.permissions.value,
                 after.id,


### PR DESCRIPTION
## Summary

Two follow-up Sentry fixes found while triaging the latest unresolved issues.

### 1. `total_votes` UnboundLocalError — `cogs/patreon_poll.py`
When the live Patreon fetch is Cloudflare-blocked **and** the DB fallback returns no `poll_option` rows, `options` is empty, the `if not options:` branch runs, and `total_votes` is never bound — crashing at the `poll_displayed_successfully` log. Initialize `total_votes = 0` before the branch.

Fixes the cluster **PYTHON-AIOHTTP-22 → 25** (7 users impacted).

### 2. Role color int→str — `cogs/stats_listeners.py`
`roles.color` is `varchar`, but `enhanced_guild_role_update` and `guild_role_create` passed the raw int `color.value`, so asyncpg raised `invalid input for query argument $2: <int> (expected str, got int)` on every role color change / role creation. Wrapped with `str()`, matching the existing `log_update` convention.

Fixes **PYTHON-AIOHTTP-6 / -26 / -27** (~300 events).

## Test plan
- [x] `ruff check` passes on both files
- [ ] Verify in staging: change a role color / create a role (no `enhanced_role_update_error`); run `/poll` against a poll with no cached options (no UnboundLocalError)

🤖 Generated with [Claude Code](https://claude.com/claude-code)